### PR TITLE
Add Anthropic pptx as a reference-only marketplace entry (slide chain step 4)

### DIFF
--- a/scripts/ingest.ts
+++ b/scripts/ingest.ts
@@ -69,6 +69,10 @@ const SkillFrontmatter = z.object({
   upstream_repo: z.string().optional(),
   original_source_url: z.string().url().optional(),
   original_author: z.string().min(1).optional(),
+  // Override the auto-generated install command. Used by reference-only entries
+  // (e.g. a third-party skill we attribute + link to but do NOT re-host) so the
+  // command installs from the upstream source instead of zynkr.ai/s/<id>.md.
+  install_command: z.string().min(1).optional(),
   security_audits: z.object({
     gen_agent_trust_hub: z.enum(["pass", "fail", "pending"]).optional(),
     socket: z.enum(["pass", "fail", "pending"]).optional(),
@@ -837,7 +841,7 @@ function ingestProjectSkills(
     sheetId: manifest.sheetId,
     kind: agentFiles.length > 0 ? "orchestrator" : "skill",
     synergy,
-    installCommand: buildInstallCommand(orchestratorId, orchestratorSlug),
+    installCommand: manifest.install_command ?? buildInstallCommand(orchestratorId, orchestratorSlug),
     updatedAt: today,
     firstSeen: readFirstSeen(orchestratorOutPath) ?? today,
     sourceRepo: repoUrl,
@@ -1400,7 +1404,7 @@ async function main() {
           legacyIpoId,
           kind: "skill",
           synergy: fm.synergy,
-          installCommand: buildInstallCommand(id, slug),
+          installCommand: fm.install_command ?? buildInstallCommand(id, slug),
           updatedAt: today,
           firstSeen: readFirstSeen(outPath) ?? today,
           sourceRepo: repoUrl,

--- a/skills/1-brand-marketing/pptx/SKILL.md
+++ b/skills/1-brand-marketing/pptx/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: pptx
+category: brand-marketing
+project: pptx
+platform: claude
+status: Done
+author: Anthropic, PBC
+description: "簡報三棒接力之後的『算繪引擎』（第四棒，由 Anthropic 維護）：把 slide-visual-selector 交出的 SLIDE_PACKET ▸ Visuals 逐頁算成真正的 .pptx 檔，也能反向讀取、解析、編修既有簡報。這是 Anthropic 官方的 pptx 技能，Zynkr 不轉散佈其程式碼——本卡片僅作引用與導流，安裝請從 Anthropic 來源取得。The .pptx rendering engine the Zynkr slide chain hands off to: it turns a per-page visual spec into an actual .pptx file (and can read / parse / edit existing decks). Authored and licensed by Anthropic — listed here only so you see the full four-step picture; install from Anthropic's source, not from Zynkr."
+input: "SLIDE_PACKET ▸ Visuals 逐頁視覺規格（由 slide-visual-selector 交棒），或一個既有的 .pptx 檔。"
+process: "讀取每頁的版式 archetype 與 pptxgenjs 原語 → 以 pptxgenjs / LibreOffice 算繪 → 輸出 .pptx；既有檔則解析、編修後回寫。"
+output: "可直接開啟、編輯的 .pptx 簡報檔。"
+synergy: ["slide-visual-selector"]
+upstream_repo: https://github.com/anthropics/skills
+original_source_url: https://github.com/anthropics/skills/blob/HEAD/skills/pptx/SKILL.md
+original_author: Anthropic, PBC
+install_command: npx skills add https://github.com/anthropics/skills --skill pptx
+---
+
+# pptx — Anthropic 官方簡報算繪技能（引用卡）
+
+> **這是引用，不是轉散佈。** `pptx` 由 Anthropic 撰寫並保有著作權（© Anthropic, PBC — All rights reserved），其授權禁止第三方重製、改作或散佈。Zynkr **不在本站託管其任何程式碼**；本頁只標註作者、連往官方來源，並提供官方安裝指令——做法與 [skills.sh](https://www.skills.sh/anthropics/skills/pptx) 相同。
+
+## 在「簡報助理」鏈中的位置（第 4 棒）
+
+```
+1. slide-storyline-designer  → ▸ Storyline   敘事骨架      （Zynkr 自製）
+2. slide-page-splitter       → ▸ Pages       每頁配置      （Zynkr 自製）
+3. slide-visual-selector     → ▸ Visuals     逐頁視覺規格  （Zynkr 自製）
+4. pptx (by Anthropic)       → .pptx 檔       算繪 ← 你在這裡
+```
+
+前三棒是 Zynkr 自製的「設計」關卡，負責想清楚每頁放什麼、長什麼樣；`pptx` 是把規格算成真正檔案的「算繪」關卡。三棒交出 `▸ Visuals` 後，由 `pptx` 收尾產出 `.pptx`。
+
+若你只需要故事線或分頁規劃、或打算改用 Canva／Google Slides 出圖，可以停在第三棒，不一定要用到 `pptx`。
+
+## 安裝（從 Anthropic 官方來源）
+
+```bash
+npx skills add https://github.com/anthropics/skills --skill pptx
+```
+
+- 官方來源：<https://github.com/anthropics/skills>（skill：`pptx`）
+- skills.sh 參考頁：<https://www.skills.sh/anthropics/skills/pptx>

--- a/skills/1-brand-marketing/slide-visual-selector/SKILL.md
+++ b/skills/1-brand-marketing/slide-visual-selector/SKILL.md
@@ -11,7 +11,7 @@ originalName: "品牌行銷助理 ─ 品牌行銷視覺呈現選擇"
 input: "slide-page-splitter 的 SLIDE_PACKET ▸ Pages 交棒包（已分頁、每頁有頁碼/對應 beat/頁面類型/標題/內容要點/資訊密度）"
 process: "逐頁用『內容特徵 → 版式 archetype』判準選版式 → 把標題與內容要點對應到 pptxgenjs 原語（addText/bullets/addTable/addChart/addShape/addImage）並寫出版面配置 → 人工審核保留/調整 → 交棒"
 output: "render-ready 的逐頁視覺規格 SLIDE_PACKET ▸ Visuals，交給已安裝的 pptx 技能（Create from scratch / pptxgenjs.md）算繪成 .pptx"
-synergy: ["slide-page-splitter"]
+synergy: ["slide-page-splitter", "pptx"]
 ---
 
 # Slide Visual Selector


### PR DESCRIPTION
## What
Surfaces the **4th step** of the 簡報 slide chain on the marketplace — `storyline-designer → page-splitter → visual-selector → **pptx (render)**` — so users see the full picture. **No Anthropic code is redistributed.**

## Why this shape
The Anthropic `pptx` skill is proprietary (`© Anthropic, PBC — All rights reserved`); its license forbids reproducing, creating derivatives, or distributing to third parties. `zynkr-skill-builder` is public, so we **cannot** vendor it. Instead we **reference** it the way [skills.sh](https://www.skills.sh/anthropics/skills/pptx) does: attribute the author, link to source, and install from Anthropic's own repo.

## Changes
- **`skills/1-brand-marketing/pptx/SKILL.md`** — pointer stub in our own words (no copied content), attributing Anthropic via the existing `upstream_repo` / `original_source_url` / `original_author` trio.
- **`scripts/ingest.ts`** — honor an optional frontmatter `install_command` override, so the card installs via `npx skills add https://github.com/anthropics/skills --skill pptx` instead of the default `zynkr.ai/s/<id>.md` (we host none of their code).
- **`slide-visual-selector`** — add `pptx` to `synergy` so the chain links forward.

## Verified locally
- `ingest.ts` + `build-marketplace.ts` run clean; entry lands as `1.28`.
- `install_command` → `npx skills add https://github.com/anthropics/skills --skill pptx` ✅
- `author` / `original_author` = `Anthropic, PBC`; upstream stars resolved (146k) ✅
- Confirmed the re-hosted body contains **none** of Anthropic's instructions (grep = 0).

Merging triggers `ingest-skills` CI to regenerate `content/`+`generated/` and surface it on the marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)