### PR TITLE
QA tollgate: tiered validate-skill engine + /skill-qa + non-bypassable CI

### DIFF
--- a/.github/workflows/ingest-skills.yml
+++ b/.github/workflows/ingest-skills.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -24,6 +26,32 @@ jobs:
       - name: Install dependencies
         working-directory: scripts
         run: npm ci
+
+      # Last-resort QA backstop: catches ERROR-tier skills that reached main
+      # without a PR (direct push / admin force-merge). Only the SKILL.md files
+      # changed in THIS push are checked, so pre-existing issues in untouched
+      # skills never block an unrelated ingest. The auto-ingest commit below
+      # only touches content/ + generated/, so it never re-triggers this gate.
+      - name: QA gate on changed skills (aborts ingest on ERROR)
+        working-directory: scripts
+        run: |
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ] || ! git cat-file -e "$BEFORE" 2>/dev/null || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            RANGE="HEAD~1 HEAD"
+          else
+            RANGE="$BEFORE ${{ github.sha }}"
+          fi
+          FILES=$(git diff --name-only $RANGE -- 'skills/**/SKILL.md' || true)
+          if [ -z "$FILES" ]; then echo "No changed SKILL.md in this push — skipping QA."; exit 0; fi
+          echo "QA-checking changed skills:"; echo "$FILES"
+          fail=0
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            echo "::group::QA $f"
+            npx tsx validate-skill.ts "../$f" --tier=all --github || fail=1
+            echo "::endgroup::"
+          done <<< "$FILES"
+          if [ "$fail" -ne 0 ]; then echo "::error::QA failed on a changed skill — aborting ingest."; exit 1; fi
 
       - name: Run ingest
         working-directory: scripts

--- a/.github/workflows/pickup-approved-issue.yml
+++ b/.github/workflows/pickup-approved-issue.yml
@@ -102,9 +102,9 @@ jobs:
           OUT=$(npx tsx ingest-from-issue.ts | tail -n1)
           echo "skill_path=$OUT" >> "$GITHUB_OUTPUT"
 
-      - name: Validate scaffolded frontmatter
+      - name: Validate + QA scaffold (blocks on ERROR-tier; stub body checks are advisory)
         working-directory: scripts
-        run: npx tsx validate-skill.ts "../${{ steps.scaffold.outputs.skill_path }}"
+        run: npx tsx validate-skill.ts "../${{ steps.scaffold.outputs.skill_path }}" --tier=all --github
 
       - name: Create branch, commit, push
         id: push

--- a/.github/workflows/publish-skill.yml
+++ b/.github/workflows/publish-skill.yml
@@ -114,9 +114,9 @@ jobs:
           # add the whole tree (matters in bundle mode where references/ landed too).
           echo "skill_dir=$(dirname "$OUT")" >> "$GITHUB_OUTPUT"
 
-      - name: Validate authored frontmatter
+      - name: Validate + QA (blocks PR on ERROR-tier findings)
         working-directory: scripts
-        run: npx tsx validate-skill.ts "../${{ steps.publish.outputs.skill_path }}"
+        run: npx tsx validate-skill.ts "../${{ steps.publish.outputs.skill_path }}" --tier=all --github
 
       - name: Create branch, commit, push
         id: push

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,48 @@
+name: QA skills
+
+# Hard QA gate on every PR to main that touches a skill. Closes the bypass that
+# the dispatch-only workflows (publish-skill.yml / pickup-approved-issue.yml)
+# leave open: hand-pushed branches and hand-opened PRs run this too. Make it a
+# REQUIRED status check in branch protection so it cannot be merged around.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'skills/**'
+
+permissions:
+  contents: read
+
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        working-directory: scripts
+        run: npm ci
+
+      - name: QA changed skills (ERROR-tier blocks the PR)
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- 'skills/**/SKILL.md' || true)
+          if [ -z "$FILES" ]; then echo "No changed SKILL.md — nothing to QA."; exit 0; fi
+          echo "QA-checking changed skills:"; echo "$FILES"
+          fail=0
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            echo "::group::QA $f"
+            ( cd scripts && npx tsx validate-skill.ts "$GITHUB_WORKSPACE/$f" --tier=all --github ) || fail=1
+            echo "::endgroup::"
+          done <<< "$FILES"
+          if [ "$fail" -ne 0 ]; then echo "::error::QA failed — fix the ERROR-tier findings above."; exit 1; fi
+          echo "All changed skills passed QA."

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,7 +8,8 @@
     "build-marketplace": "tsx build-marketplace.ts",
     "build-tree": "tsx build-taxonomy-tree.ts",
     "check-ipo": "tsx check-ipo-drift.ts",
-    "validate": "tsx validate-skill.ts"
+    "validate": "tsx validate-skill.ts",
+    "qa": "tsx validate-skill.ts --tier=all"
   },
   "dependencies": {
     "gray-matter": "^4.0.3",

--- a/scripts/validate-skill.ts
+++ b/scripts/validate-skill.ts
@@ -1,21 +1,29 @@
 #!/usr/bin/env tsx
 /**
- * Local frontmatter validator. Run before pushing to catch the same Zod
- * failures CI would flag during ingest.
+ * Layered, tier-aware QA engine for SKILL.md files — the single source of
+ * truth shared by CI and the /skill-qa skill.
  *
- *   npm run validate skills/2-sales-consultant/foo/SKILL.md
+ *   npm run validate skills/2-sales-consultant/foo/SKILL.md   # ERROR-tier only (CI default)
  *   npm run validate skills/2-sales-consultant/foo            # resolves SKILL.md
  *   npm run validate skills/2-sales-consultant                # scans the tree
+ *   tsx scripts/validate-skill.ts <path> --tier=all           # also print WARN + INFO
+ *   tsx scripts/validate-skill.ts <path> --json               # machine-readable (for /skill-qa)
  *
- * Exits non-zero if any SKILL.md fails. Schema mirrors scripts/ingest.ts —
- * keep in sync if SkillFrontmatter or TAXONOMY there change.
+ * Exit codes: 0 = no ERROR · 1 = >=1 ERROR · 2 = usage/IO error.
+ * The exit code is governed SOLELY by ERROR count, regardless of --tier, so a
+ * `--tier=all` run for annotations never blocks CI.
+ *
+ * Tiers: ERROR blocks (PR/publish), WARN advises, INFO is a note only.
+ * Frontmatter schema + TAXONOMY mirror scripts/ingest.ts — keep in sync if
+ * either changes there. (We do NOT import ingest.ts: it runs main() on import.)
  */
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 import matter from "gray-matter";
 import { z } from "zod";
 
-const TAXONOMY: Record<string, number> = {
+export const TAXONOMY: Record<string, number> = {
   "strategy": 0,
   "brand-marketing": 1,
   "sales-consultant": 2,
@@ -28,7 +36,7 @@ const TAXONOMY: Record<string, number> = {
   "legal": 9,
 };
 
-const SkillFrontmatter = z.object({
+export const SkillFrontmatter = z.object({
   name: z.string().min(1),
   category: z.string().refine((v) => v in TAXONOMY, {
     message: `Must be one of: ${Object.keys(TAXONOMY).join(", ")}`,
@@ -45,6 +53,7 @@ const SkillFrontmatter = z.object({
   upstream_repo: z.string().optional(),
   original_source_url: z.string().url().optional(),
   original_author: z.string().min(1).optional(),
+  install_command: z.string().min(1).optional(),
   security_audits: z.object({
     gen_agent_trust_hub: z.enum(["pass", "fail", "pending"]).optional(),
     socket: z.enum(["pass", "fail", "pending"]).optional(),
@@ -69,14 +78,352 @@ const SkillFrontmatter = z.object({
   }
 });
 
+// IPO soft length limits — mirror scripts/ingest.ts:33-35 (ingest silently
+// truncates; QA only warns so the author sees the clip coming).
+const MAX_INPUT_LENGTH = 180;
+const MAX_PROCESS_LENGTH = 260;
+const MAX_OUTPUT_LENGTH = 180;
+
+export type Tier = "ERROR" | "WARN" | "INFO";
+export interface QaFinding {
+  check: string;
+  tier: Tier;
+  message: string;
+  file: string;
+  line?: number;
+  fixable?: boolean;
+  suggestion?: string;
+}
+
+// ── small helpers ────────────────────────────────────────────────────────────
+
+// Mirror of toSlug in scripts/ingest.ts:209-216.
+function toSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/[\s_]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function collapse(v: unknown): string {
+  return typeof v === "string" ? v.replace(/\s+/g, " ").trim() : "";
+}
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), "..", "..");
+
+interface SkillInfo {
+  data: Record<string, any>;
+  body: string;
+  bodyLines: string[];
+  bodyStartLine: number; // 1-based raw line where the body begins
+  hasFrontmatter: boolean;
+}
+
+function readSkill(filePath: string): SkillInfo {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const parsed = matter(raw);
+  const data = (parsed.data ?? {}) as Record<string, any>;
+  const hasFrontmatter = data && Object.keys(data).length > 0;
+
+  // Compute the raw line where the body starts so findings carry true line numbers.
+  const lines = raw.split("\n");
+  let bodyStartLine = 1;
+  if (lines[0]?.trim() === "---") {
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i].trim() === "---") {
+        bodyStartLine = i + 2; // 1-based line after the closing delimiter
+        break;
+      }
+    }
+  }
+  const body = parsed.content ?? "";
+  return { data, body, bodyLines: body.split("\n"), bodyStartLine, hasFrontmatter };
+}
+
+// Reference-only / lifted entries (e.g. the Anthropic pptx card, vercel-labs
+// lift-and-shift): they legitimately have no Step/Workflow body, an H1 that
+// differs from the slug, and an upstream install URL. Body-structure findings
+// downgrade to INFO for these so they never block.
+function isReferenceEntry(data: Record<string, any>, hasWorkflow: boolean): boolean {
+  if (data.install_command) return true;
+  const author = String(data.author ?? "");
+  const trio = data.upstream_repo && data.original_source_url && data.original_author;
+  if (trio && !/peter\s*tu/i.test(author)) return true;
+  if (data["disable-model-invocation"] === true && !hasWorkflow) return true;
+  return false;
+}
+
+// Scaffold stubs (pre-/skill-creator): don't block body-structure as ERROR;
+// the author fills them in and flips status before publishing.
+function isStub(data: Record<string, any>, body: string): boolean {
+  return data.status === "Not started" || /<!--\s*TODO/i.test(body);
+}
+
+// Downgrade a body-check tier per escape hatches.
+function bodyTier(base: Tier, isRef: boolean, stub: boolean): Tier {
+  if (isRef) return "INFO";
+  if (stub && base === "ERROR") return "WARN";
+  return base;
+}
+
+let _skillNames: Set<string> | null = null;
+function skillNameSet(): Set<string> {
+  if (_skillNames) return _skillNames;
+  const names = new Set<string>();
+  const skillsDir = path.join(REPO_ROOT, "skills");
+  const walk = (dir: string) => {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name === "SKILL.md") {
+        try {
+          const d = matter(fs.readFileSync(full, "utf-8")).data as Record<string, any>;
+          if (typeof d?.name === "string") names.add(d.name);
+        } catch { /* ignore unreadable */ }
+      }
+    }
+  };
+  walk(skillsDir);
+  _skillNames = names;
+  return names;
+}
+
+// ── checks ───────────────────────────────────────────────────────────────────
+
+function checkFrontmatter(file: string, info: SkillInfo): QaFinding[] {
+  const out: QaFinding[] = [];
+  if (!info.hasFrontmatter) {
+    out.push({ check: "frontmatter.present", tier: "ERROR", file, line: 1,
+      message: "No YAML frontmatter found." });
+    return out;
+  }
+  const parsed = SkillFrontmatter.safeParse(info.data);
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      out.push({ check: "frontmatter.schema", tier: "ERROR", file, line: 1,
+        message: `${issue.path.join(".") || "(root)"}: ${issue.message}` });
+    }
+  }
+  if (info.data.install_command !== undefined && typeof info.data.install_command !== "string") {
+    out.push({ check: "frontmatter.install_command_known", tier: "WARN", file, line: 1,
+      message: "install_command should be a string." });
+  }
+  return out;
+}
+
+function checkBody(file: string, info: SkillInfo): QaFinding[] {
+  const out: QaFinding[] = [];
+  const { bodyLines, bodyStartLine, data, body } = info;
+  const rawLine = (i: number) => bodyStartLine + i;
+
+  const h1Idxs = bodyLines.map((l, i) => ({ l, i })).filter((x) => /^#\s+\S/.test(x.l));
+  const firstH2Idx = bodyLines.findIndex((l) => /^##\s+\S/.test(l));
+  const snippetIdxs = bodyLines.map((l, i) => ({ l, i })).filter((x) => /npx\s+skills\s+add/i.test(x.l));
+  const hasWorkflow = bodyLines.some((l) => /^##\s+(Step\b|Workflow\b)/i.test(l));
+
+  const isRef = isReferenceEntry(data, hasWorkflow);
+  const stub = isStub(data, body);
+  const name = typeof data.name === "string" ? data.name : "";
+  const nameSlug = toSlug(name);
+
+  // body.h1_present
+  if (h1Idxs.length === 0) {
+    out.push({ check: "body.h1_present", tier: bodyTier("ERROR", isRef, stub), file, line: bodyStartLine,
+      message: "No H1 title (`# ...`) in the body.", fixable: false,
+      suggestion: `Add a top-level "# ${name}" heading.` });
+  } else if (h1Idxs.length > 1) {
+    out.push({ check: "body.h1_present", tier: isRef ? "INFO" : "WARN", file, line: rawLine(h1Idxs[1].i),
+      message: `Multiple H1 headings (${h1Idxs.length}); a SKILL.md should have exactly one.` });
+  }
+
+  // body.h1_matches_name
+  if (h1Idxs.length > 0 && nameSlug) {
+    const h1Text = h1Idxs[0].l.replace(/^#\s+/, "");
+    const h1Slug = toSlug(h1Text);
+    if (!h1Slug.includes(nameSlug)) {
+      out.push({ check: "body.h1_matches_name", tier: isRef ? "INFO" : "WARN", file, line: rawLine(h1Idxs[0].i),
+        message: `H1 "${h1Text}" does not reflect name "${name}".`, fixable: !isRef,
+        suggestion: `Rename H1 to include "${name}".` });
+    }
+  }
+
+  // body.install_snippet — WARN, not ERROR: most of the existing catalog omits
+  // the body snippet (the marketplace auto-generates the install command), so
+  // blocking on it would fail ~1/3 of skills. SKILL_SPEC §2 stays a nudge.
+  if (snippetIdxs.length === 0) {
+    out.push({ check: "body.install_snippet", tier: bodyTier("WARN", isRef, stub), file, line: bodyStartLine,
+      message: "No install snippet (`npx skills add ... --skill <slug>`) in the body.", fixable: !isRef,
+      suggestion: `Add near the top:\n\`\`\`bash\nnpx skills add https://github.com/peter-tu-zynkr/zynkr-skill-builder --skill ${name}\n\`\`\`` });
+  } else {
+    if (snippetIdxs.length > 1) {
+      out.push({ check: "body.install_snippet", tier: isRef ? "INFO" : "WARN", file, line: rawLine(snippetIdxs[1].i),
+        message: `${snippetIdxs.length} install snippets found; SKILL_SPEC §2 expects exactly one.` });
+    }
+    const first = snippetIdxs[0];
+    const m = first.l.match(/npx\s+skills\s+add\s+(\S+)\s+--skill\s+(\S+)/i);
+    if (m && nameSlug && toSlug(m[2]) !== nameSlug) {
+      out.push({ check: "body.install_snippet", tier: bodyTier("WARN", isRef, stub), file, line: rawLine(first.i),
+        message: `Install snippet --skill "${m[2]}" != name "${name}".`, fixable: !isRef,
+        suggestion: `Change --skill to ${name}.` });
+    }
+    const nearTop = firstH2Idx === -1 || first.i < firstH2Idx;
+    if (!nearTop) {
+      out.push({ check: "body.install_snippet", tier: isRef ? "INFO" : "WARN", file, line: rawLine(first.i),
+        message: "Install snippet appears after the first `## ` heading; SKILL_SPEC §2 wants it near the top." });
+    }
+  }
+
+  // body.summary_paragraph
+  const summaryEnd = firstH2Idx === -1 ? bodyLines.length : firstH2Idx;
+  const summaryStart = h1Idxs.length > 0 ? h1Idxs[0].i + 1 : 0;
+  const hasProse = bodyLines.slice(summaryStart, summaryEnd).some((l) => {
+    const t = l.trim();
+    return t.length > 40 && !/^[#>\-*|]/.test(t) && !/^```/.test(t) && !/npx\s+skills\s+add/i.test(t);
+  });
+  if (!hasProse) {
+    out.push({ check: "body.summary_paragraph", tier: isRef ? "INFO" : "WARN", file, line: bodyStartLine,
+      message: "No summary paragraph (plain prose: what it does + when to trigger) before the first `## ` section." });
+  }
+
+  // body.workflow_present — WARN, not ERROR: many shipped internal skills
+  // structure their body with other headings; blocking would fail them.
+  if (!hasWorkflow) {
+    out.push({ check: "body.workflow_present", tier: bodyTier("WARN", isRef, stub), file, line: bodyStartLine,
+      message: "No `## Step N` or `## Workflow` section — SKILL_SPEC §4 recommends a numbered or linear workflow.",
+      fixable: false, suggestion: "Add `## Step 1`, `## Step 2`, … or a `## Workflow` section." });
+  }
+
+  return out;
+}
+
+function checkPaths(file: string, info: SkillInfo): QaFinding[] {
+  const out: QaFinding[] = [];
+  // Match real machine-specific home paths but NOT doc placeholders like
+  // /Users/<name>/ (the segment after the prefix must be word-chars).
+  const absHome = /(?:\/Users\/|\/home\/|\/root\/)[A-Za-z0-9._-]+\//;
+  const winHome = /[A-Za-z]:\\Users\\[A-Za-z0-9._-]+/;
+  info.bodyLines.forEach((l, i) => {
+    if (absHome.test(l) || winHome.test(l)) {
+      out.push({ check: "paths.absolute_home", tier: "ERROR", file, line: info.bodyStartLine + i,
+        message: `Absolute home-dir path leaked: "${l.trim().slice(0, 80)}". SKILL_SPEC §5 forbids machine-specific paths.`,
+        fixable: true, suggestion: "Use a relative path (./...) or the {{SKILL_DIR}} placeholder." });
+    }
+    if (/<!--\s*SKILL BASE PATH/i.test(l)) {
+      out.push({ check: "paths.skill_dir_literal", tier: "WARN", file, line: info.bodyStartLine + i,
+        message: "Legacy `<!-- SKILL BASE PATH -->` comment; remove it (SKILL_SPEC §5)." });
+    }
+  });
+  return out;
+}
+
+function checkSynergy(file: string, info: SkillInfo): QaFinding[] {
+  const out: QaFinding[] = [];
+  const syn = Array.isArray(info.data.synergy) ? info.data.synergy : [];
+  if (syn.length === 0) return out;
+  const names = skillNameSet();
+  const self = typeof info.data.name === "string" ? info.data.name : "";
+  for (const slug of syn) {
+    if (typeof slug !== "string") continue;
+    if (slug === self) continue; // self-reference is a known quirk, not a break
+    if (!names.has(slug)) {
+      out.push({ check: "synergy.slugs_exist", tier: "WARN", file, line: 1,
+        message: `synergy references "${slug}", which is not an existing skill name under skills/**.` });
+    }
+  }
+  return out;
+}
+
+function checkIpo(file: string, info: SkillInfo): QaFinding[] {
+  const out: QaFinding[] = [];
+  const checks: [string, number][] = [
+    ["input", MAX_INPUT_LENGTH], ["process", MAX_PROCESS_LENGTH], ["output", MAX_OUTPUT_LENGTH],
+  ];
+  for (const [field, max] of checks) {
+    const len = collapse(info.data[field]).length;
+    if (len > max) {
+      out.push({ check: "ipo.length", tier: "WARN", file, line: 1,
+        message: `frontmatter "${field}" is ${len} chars (> ${max}); ingest will silently truncate it.` });
+    }
+  }
+  return out;
+}
+
+function checkAttribution(file: string, info: SkillInfo): QaFinding[] {
+  const out: QaFinding[] = [];
+  const author = String(info.data.author ?? "");
+  if (/\(derivative of/i.test(author)) {
+    const hasSection = /^##\s+Attribution\b/im.test(info.body);
+    if (!hasSection) {
+      out.push({ check: "attribution.case_c_section", tier: "WARN", file, line: 1,
+        message: 'Author is a derivative (Case C) but no `## Attribution` section describes the changes (SKILL_SPEC §6).' });
+    }
+  }
+  return out;
+}
+
+function checkDownload(file: string, info: SkillInfo): QaFinding[] {
+  const out: QaFinding[] = [];
+  // source_path_exists: the artifact must be readable + non-empty.
+  if (!info.body.trim() && !info.hasFrontmatter) {
+    out.push({ check: "download.source_path_exists", tier: "ERROR", file, line: 1,
+      message: "SKILL.md is empty — nothing to install." });
+  }
+  // install_url_wellformed: validate the body install snippet's URL.
+  const snippet = info.bodyLines.find((l) => /npx\s+skills\s+add/i.test(l));
+  if (snippet) {
+    const m = snippet.match(/npx\s+skills\s+add\s+(\S+)/i);
+    if (m) {
+      const ok = z.string().url().safeParse(m[1]).success && /^https?:\/\/github\.com\//i.test(m[1]);
+      if (!ok) {
+        out.push({ check: "download.install_url_wellformed", tier: "WARN", file, line: 1,
+          message: `Install URL "${m[1]}" is not a well-formed github.com URL.` });
+      }
+    }
+  }
+  // relative_refs_resolve: ./refs in the body should exist next to the skill.
+  const skillDir = path.dirname(file);
+  const refRe = /\]\((\.\/[^)\s]+)\)|`(\.\/[^`\s]+)`/g;
+  let mm: RegExpExecArray | null;
+  const seen = new Set<string>();
+  while ((mm = refRe.exec(info.body))) {
+    const ref = (mm[1] || mm[2]).replace(/[#?].*$/, "");
+    if (seen.has(ref)) continue;
+    seen.add(ref);
+    if (!fs.existsSync(path.join(skillDir, ref))) {
+      out.push({ check: "body.relative_refs_resolve", tier: "INFO", file, line: 1,
+        message: `Relative reference "${ref}" does not resolve under ${path.relative(REPO_ROOT, skillDir)} (ok if it lands in the same PR bundle).` });
+    }
+  }
+  // live_check is post-ship only.
+  out.push({ check: "download.live_check", tier: "INFO", file, line: 1,
+    message: "Live download (zynkr.ai/s/<id>.md) is verified post-ship by /skill-triager Option D." });
+  return out;
+}
+
+export function runChecks(filePath: string): QaFinding[] {
+  const info = readSkill(filePath);
+  return [
+    ...checkFrontmatter(filePath, info),
+    ...checkBody(filePath, info),
+    ...checkPaths(filePath, info),
+    ...checkSynergy(filePath, info),
+    ...checkIpo(filePath, info),
+    ...checkAttribution(filePath, info),
+    ...checkDownload(filePath, info),
+  ];
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
 function collectSkillFiles(target: string): string[] {
   const stat = fs.statSync(target);
   if (stat.isFile()) return [target];
   const skillMd = path.join(target, "SKILL.md");
   if (fs.existsSync(skillMd)) return [skillMd];
-
-  // Tree scan: only descend looking for SKILL.md, ignore sibling docs
-  // (README.md, CLAUDE.md, etc.) that ingest.ts doesn't pick up either.
   const found: string[] = [];
   for (const entry of fs.readdirSync(target, { withFileTypes: true })) {
     if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
@@ -86,24 +433,53 @@ function collectSkillFiles(target: string): string[] {
   return found;
 }
 
-function validateOne(filePath: string): { ok: boolean; issues: string[] } {
-  const raw = fs.readFileSync(filePath, "utf-8");
-  const { data } = matter(raw);
-  if (!data || Object.keys(data).length === 0) {
-    return { ok: false, issues: ["No frontmatter"] };
-  }
-  const parsed = SkillFrontmatter.safeParse(data);
-  if (parsed.success) return { ok: true, issues: [] };
-  const issues = parsed.error.issues.map(
-    (i) => `${i.path.join(".") || "(root)"}: ${i.message}`
-  );
-  return { ok: false, issues };
+interface FileResult {
+  file: string;
+  pass: boolean;
+  errors: number;
+  warns: number;
+  infos: number;
+  findings: QaFinding[];
 }
 
-function main() {
-  const arg = process.argv[2];
+function summarize(file: string, findings: QaFinding[]): FileResult {
+  const errors = findings.filter((f) => f.tier === "ERROR").length;
+  const warns = findings.filter((f) => f.tier === "WARN").length;
+  const infos = findings.filter((f) => f.tier === "INFO").length;
+  return { file, pass: errors === 0, errors, warns, infos, findings };
+}
+
+const GLYPH: Record<Tier, string> = { ERROR: "❌", WARN: "⚠️ ", INFO: "ℹ️ " };
+
+function printText(result: FileResult, showTiers: Set<Tier>): void {
+  const rel = path.relative(process.cwd(), result.file);
+  const head = result.pass ? "✓" : "✗";
+  console.log(`  ${head}  ${rel}  —  ${result.errors} error(s), ${result.warns} warning(s)`);
+  for (const f of result.findings) {
+    if (!showTiers.has(f.tier)) continue;
+    const loc = f.line ? `:${f.line}` : "";
+    console.log(`       ${GLYPH[f.tier]} ${f.tier}  ${f.check}  (${rel}${loc})`);
+    console.log(`            ${f.message}`);
+    if (f.suggestion && showTiers.has(f.tier)) {
+      for (const sline of f.suggestion.split("\n")) console.log(`            ↳ ${sline}`);
+    }
+  }
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const flags = new Set(argv.filter((a) => a.startsWith("--")));
+  const positional = argv.filter((a) => !a.startsWith("--"));
+  const tierFlag = [...flags].find((f) => f.startsWith("--tier="))?.split("=")[1] ?? "error";
+  const asJson = flags.has("--json");
+  const asGithub = flags.has("--github"); // emit ::error/::warning PR annotations
+  const showTiers: Set<Tier> = tierFlag === "all"
+    ? new Set<Tier>(["ERROR", "WARN", "INFO"])
+    : new Set<Tier>(["ERROR"]);
+
+  const arg = positional[0];
   if (!arg) {
-    console.error("Usage: tsx scripts/validate-skill.ts <path-to-SKILL.md|skill-dir|skills-tree>");
+    console.error("Usage: tsx scripts/validate-skill.ts <SKILL.md|skill-dir|tree> [--tier=error|all] [--json]");
     process.exit(2);
   }
   const target = path.resolve(arg);
@@ -111,28 +487,41 @@ function main() {
     console.error(`Not found: ${target}`);
     process.exit(2);
   }
-
   const files = collectSkillFiles(target).filter((f) => f.endsWith(".md"));
   if (files.length === 0) {
     console.error(`No SKILL.md found under ${target}`);
     process.exit(2);
   }
 
-  let failed = 0;
-  for (const file of files) {
-    const { ok, issues } = validateOne(file);
-    const rel = path.relative(process.cwd(), file);
-    if (ok) {
-      console.log(`  ✓  ${rel}`);
-    } else {
-      failed += 1;
-      console.log(`  ✗  ${rel}`);
-      issues.forEach((i) => console.log(`       ${i}`));
+  const results = files.map((f) => summarize(f, runChecks(f)));
+  const totalErrors = results.reduce((n, r) => n + r.errors, 0);
+
+  if (asGithub) {
+    // GitHub Actions workflow-command annotations (show inline on the PR).
+    for (const r of results) {
+      for (const f of r.findings) {
+        if (f.tier === "INFO") continue;
+        const level = f.tier === "ERROR" ? "error" : "warning";
+        const rel = path.relative(REPO_ROOT, f.file);
+        const msg = `${f.check}: ${f.message}`.replace(/[\r\n]+/g, " ");
+        console.log(`::${level} file=${rel}${f.line ? `,line=${f.line}` : ""}::${msg}`);
+      }
     }
   }
 
-  console.log(`\n${files.length - failed}/${files.length} valid`);
-  process.exit(failed > 0 ? 1 : 0);
+  if (asJson) {
+    console.log(JSON.stringify(results, null, 2));
+  } else {
+    for (const r of results) printText(r, showTiers);
+    const passed = results.filter((r) => r.pass).length;
+    const warns = results.reduce((n, r) => n + r.warns, 0);
+    console.log(`\n${passed}/${results.length} pass (0 errors)` +
+      (totalErrors ? ` · ${totalErrors} error(s)` : "") +
+      (warns ? ` · ${warns} warning(s)${tierFlag === "all" ? "" : " (run --tier=all to see them)"}` : ""));
+  }
+
+  process.exit(totalErrors > 0 ? 1 : 0);
 }
 
-main();
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) main();

--- a/skills/6-engineer/skill-publish/SKILL.md
+++ b/skills/6-engineer/skill-publish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-publish
-description: "Land a freshly-built SKILL.md into the Zynkr skills pipeline — the closing step of the canonical 4-skill chain (/skill-sourcer → /skill-triager → /skill-creator → /skill-publish). Attaches the artifact to the existing pipeline issue, fires the publish-skill workflow to open a PR, and hands off to /skill-triager confirm-ship for closure. Trigger on phrases like 'publish this skill', 'land this skill', 'I finished building, push it', 'register this skill', 'add this built skill', 'check category and dedup before upload', or '/skill-publish'. Use whenever the user has a finished SKILL.md and wants it landed in zynkr-skill-builder — whether it came from /skill-creator (happy path) or from elsewhere (fresh intake fallback)."
+description: "Land a freshly-built SKILL.md into the Zynkr skills pipeline — the closing step of the canonical chain (/skill-sourcer → /skill-triager → /skill-creator → /skill-qa → /skill-publish). Attaches the artifact to the existing pipeline issue, fires the publish-skill workflow to open a PR, and hands off to /skill-triager confirm-ship for closure. Trigger on phrases like 'publish this skill', 'land this skill', 'I finished building, push it', 'register this skill', 'add this built skill', 'check category and dedup before upload', or '/skill-publish'. Use whenever the user has a finished SKILL.md and wants it landed in zynkr-skill-builder — whether it came from /skill-creator (happy path) or from elsewhere (fresh intake fallback)."
 category: engineer
 project: skill-publish
 platform: claude
@@ -27,11 +27,25 @@ The **closing step** of the Zynkr skill pipeline. `/skill-publish` lands a finis
 > **Canonical chain (the happy path you'll hit 80% of the time):**
 >
 > ```
-> /skill-sourcer  →  /skill-triager  →  /skill-creator  →  /skill-publish
->   (find idea)      (approve)         (build content)    (land + ship)
+> /skill-sourcer  →  /skill-triager  →  /skill-creator  →  /skill-qa  →  /skill-publish
+>   (find idea)      (approve)         (build content)    (QA gate)    (land + ship)
 > ```
 >
 > By the time `/skill-publish` runs, a GitHub issue already exists in `peter-tu-zynkr/zynkr-skill-idea` with `Pipeline Status=approved`, a slug + category, and an open `skill/<slug>` branch carrying the stub SKILL.md. `/skill-creator` produced the real content. `/skill-publish` just attaches the artifact to that existing pipeline state, fires `publish-skill.yml` to open the PR, and lets `/skill-triager` close the loop after merge.
+
+---
+
+## Step 0 — QA gate (mandatory, runs in both modes)
+
+Before anything else, the SKILL.md must clear QA. Invoke `/skill-qa <path>` on the artifact and read its verdict:
+
+- **Recent-PASS short-circuit:** if `/zynkr` already ran `/skill-qa` on this same artifact this turn and it PASSed, record "QA: PASS (from front-door)" and proceed — don't re-run.
+- **ERROR-tier fail → HARD STOP.** Do not detect mode, do not dispatch (Step 5's dispatch is the only state-changing step). Print the QA report's ERRORs with their fixes and tell the user to fix and re-run `/skill-publish`.
+- **WARN-only → advise, then ask:** "QA passed with N warnings (listed). Publish anyway, or fix first?" Default to publishing with the warnings recorded. WARN never blocks.
+
+Print a one-line verdict at the top of your output: `QA: PASS (0 errors, N warnings)` or `QA: FAIL (M errors) — not publishing.`
+
+This is the interactive half of the tollgate; CI (`publish-skill.yml` / `qa.yml`) re-runs the same engine as a hard backstop, so a skipped or overridden Step 0 still cannot land an ERROR-tier skill on `main`.
 
 ---
 
@@ -133,6 +147,8 @@ Then fall through to Step 5.
 
 ## Step 5 — Fire `publish-skill.yml` dispatch (both modes)
 
+> **Pre-flight:** do not reach this step unless Step 0 returned **QA PASS** (or WARN-only with explicit user override). The dispatch is the one state-changing action — never fire it for an ERROR-tier skill.
+
 Identical for continuation and fresh intake. The dispatch event is what makes the SKILL.md actually land in the repo.
 
 Pick **one** of the three payload shapes — `skill_md_url`, `skill_md_b64`, or `bundle_b64`. The workflow rejects payloads with more than one or none.
@@ -207,7 +223,7 @@ gh run list --repo peter-tu-zynkr/zynkr-skill-builder \
 
 The workflow:
 1. Writes `skills/<N-cat>/<slug>/SKILL.md` (idempotent — refuses to overwrite)
-2. Validates frontmatter via `validate-skill.ts`
+2. Runs the QA gate (`validate-skill.ts` — frontmatter + body + path-leak ERROR checks); blocks the PR on any ERROR
 3. Creates branch `skill/<slug>`, opens a PR titled `publish(<slug>): from peter-tu-zynkr/zynkr-skill-idea#<num>`
 4. Comments back on the source issue with the PR URL
 
@@ -250,6 +266,7 @@ When you're done with `/skill-publish`, tell the user:
 **Completion checklist (mode-dependent):**
 
 Continuation mode (happy path):
+- [ ] **QA Step 0 returned PASS** (or WARN-only override) — ERROR-tier never published
 - [ ] Artifact located, frontmatter parsed
 - [ ] Existing pipeline issue identified and confirmed with user
 - [ ] Category cross-check passes (or mismatch resolved)
@@ -272,6 +289,8 @@ Ask: **"Want to publish another skill?"**
 ## Where this skill can decouple from the others
 
 The canonical chain is opinionated, but each handoff has a clean break-point you can use:
+
+> **QA is the one step you cannot decouple from.** Even hand-committed skills (the pre-push fallback, a manual PR, a direct commit) must clear the CI QA backstop (`qa.yml` required check + the `ingest-skills.yml` pre-step). Skipping Step 0 locally only defers the gate to CI; it does not remove it.
 
 ### Decouple from `/skill-sourcer`
 
@@ -308,6 +327,7 @@ The canonical chain is opinionated, but each handoff has a clean break-point you
 ## Error handling
 
 - **SKILL.md missing required frontmatter:** ask the user to fill it before continuing — `validate-skill.ts` will block the workflow anyway.
+- **QA ERROR-tier fail (Step 0):** treat like missing frontmatter — stop and re-prompt with the QA report; CI's `qa.yml` would block the PR anyway.
 - **Artifact path doesn't exist:** stop and re-prompt.
 - **Continuation mode but the issue isn't `approved`:** flag it — the user may have meant a different issue, or the triager step was skipped. Confirm before attaching.
 - **Existing target file in the repo (idempotency block):** `publish-skill.ts` exits 3. The slug is already taken — pick a different slug, or update the existing skill via a normal PR instead of re-dispatching.

--- a/skills/6-engineer/skill-qa/SKILL.md
+++ b/skills/6-engineer/skill-qa/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: skill-qa
+description: "Quality-gate a SKILL.md before it ships — runs the shared validate-skill.ts engine (frontmatter + body structure + absolute-path leak scan + synergy + IPO length + downloadability) and renders a per-check ✅/⚠️/❌ report with file:line and fix suggestions, optionally auto-fixing mechanical issues (strip leaked machine paths, repair the install snippet) with confirmation, then emits a PASS/FAIL verdict gated on ERROR-tier checks. The QA tollgate of the skill pipeline, between /skill-creator and /skill-publish — and the ad-hoc health-check /zynkr routes to. Trigger on 'qa this skill', 'check this SKILL.md', 'is this skill ready to ship', 'lint the skill', '健檢', 'does <slug> pass QA', or '/skill-qa'."
+category: engineer
+project: skill-qa
+platform: claude
+status: WIP
+author: Peter Tu
+disable-model-invocation: true
+input: "A target SKILL.md: a file path, a skill folder, a skill/<slug> branch, or a bare slug to resolve under skills/**."
+process: "Locate target → run validate-skill.ts --tier=all --json → render a tiered report → offer HITL auto-fixes for mechanical findings → emit PASS (0 errors) / FAIL verdict and hand off to /skill-publish."
+output: "A QA report (✅/⚠️/❌ per check with file:line + fix), a PASS/FAIL verdict gated on ERROR-tier checks, and optional confirmed auto-fixes applied to the working tree."
+synergy: ["skill-publish", "skill-triager", "zynkr"]
+---
+
+# skill-qa
+
+```bash
+npx skills add https://github.com/peter-tu-zynkr/zynkr-skill-builder --skill skill-qa
+```
+
+The **quality tollgate** of the skill pipeline. Run it on a finished `SKILL.md` after `/skill-creator` and before `/skill-publish`, or any time you want to health-check a skill — `/zynkr` routes "qa `<slug>`" / 「健檢」 here. It does not author or publish; it inspects, reports, and (with your OK) fixes mechanical issues, then returns a clear PASS/FAIL.
+
+QA is a thin wrapper over one engine — `scripts/validate-skill.ts`. Never re-implement a check here: that script is the single source of truth CI also runs, so a local PASS means CI's QA check will pass too.
+
+---
+
+## Step 1 — Locate the target
+
+Resolve the target SKILL.md, in priority order:
+
+1. An explicit file path → use it.
+2. A skill-folder path → `./SKILL.md` inside it.
+3. A `skill/<slug>` branch → `git fetch origin <branch>`, then read `skills/**/<slug>/SKILL.md` on that ref.
+4. A bare slug → glob `skills/**/<slug>/SKILL.md`. If more than one matches, list them and ask which.
+5. Nothing resolvable → ask: "Point me at the SKILL.md — a path, slug, or branch."
+
+## Step 2 — Run the engine
+
+From `scripts/`, run the shared engine in JSON mode:
+
+```bash
+npx tsx scripts/validate-skill.ts <resolved-path> --tier=all --json
+```
+
+Parse the output — an array of per-file objects `{ file, pass, errors, warns, infos, findings[] }`, where each finding is `{ check, tier, message, file, line, fixable, suggestion }`. Do not re-run individual checks by hand.
+
+## Step 3 — Render the report
+
+Lead with the verdict line, then group findings by tier:
+
+- ❌ **ERROR** (blocks ship) — frontmatter schema failure, missing H1 title, leaked machine-specific absolute path.
+- ⚠️ **WARN** (advisory) — no install snippet / workflow section, synergy slug not found, IPO field over length.
+- ℹ️ **INFO** (notes) — reference-entry downgrades, the post-ship live-download reminder.
+
+For each finding print `<glyph> <CHECK> (<file>:<line>) — <message>`, and the `suggestion` beneath it when present.
+
+## Step 4 — Offer auto-fix (HITL)
+
+For findings flagged `fixable: true`, propose the concrete edit and **ask before writing**:
+
+- `paths.absolute_home` → show the offending line; propose a repo-relative path or the `{{SKILL_DIR}}` placeholder.
+- `body.install_snippet` (missing or wrong slug) → insert or repair the snippet immediately after the H1.
+- `body.h1_matches_name` → offer to rename the H1 (skip for reference entries).
+
+Never auto-fix prose checks (`body.summary_paragraph`, `attribution.case_c_section`) — leave those as TODOs for the author. After applying any fix, re-run Step 2 to confirm it cleared.
+
+## Step 5 — Verdict & handoff
+
+- **PASS** (0 ERROR): say so, note the WARN count, and point to `/skill-publish`. If `/zynkr` chained you here, return a PASS so it can continue to publish.
+- **FAIL** (≥1 ERROR): list the blocking ERRORs and stop. Tell the user to fix and re-run `/skill-qa`. Never publish on a FAIL.
+
+QA is a **pre-ship** gate. The live-download check (that `zynkr.ai/s/<id>.md` resolves) runs **post-ship** in `/skill-triager` Option D — `/skill-qa` only emits an INFO pointer to it.
+
+---
+
+## Error handling
+
+- **Target not found / empty** → report and ask for a valid path or slug.
+- **Ambiguous slug** (multiple matches) → list them and ask which.
+- **Branch fetch fails** → report the git error; offer to QA the local working copy instead.
+- **Engine exits 2** (usage/IO) → a tooling failure, not a skill FAIL; surface stderr and retry. Exit 1 means real ERROR findings (a genuine FAIL).
+
+## Reuse, don't reinvent
+
+Every check lives in `scripts/validate-skill.ts` — the same engine run by CI (`qa.yml`, `publish-skill.yml`, `pickup-approved-issue.yml`). `/skill-qa` only locates the target, runs the engine, presents results, and applies confirmed fixes. If a new check is needed, add it to the engine; never fork the logic into this skill. The pipeline order is `/skill-sourcer → /skill-triager → /skill-creator → /skill-qa → /skill-publish`.

--- a/skills/6-engineer/skill-triager/SKILL.md
+++ b/skills/6-engineer/skill-triager/SKILL.md
@@ -14,15 +14,15 @@ disable-model-invocation: true
 
 # Skill Triager
 
-The **gate** of the canonical 4-skill chain — runs twice:
+The **gate** of the skill-authoring chain — runs twice:
 
 - **Option A `assign-build`** (front-gate): the second-look approval right after `/skill-sourcer`. Fires `skill-build-request` → `pickup-approved-issue.yml` opens a `skill/<slug>` PR with a stub for `/skill-creator` to fill.
 - **Option D `confirm-ship`** (back-gate): the audit closer after `/skill-publish` lands the SKILL.md and `ingest-skills.yml` publishes it live. Three read-only checks, then flips Project to `shipped`.
 
 ```
-/skill-sourcer  →  /skill-triager  →  /skill-creator  →  /skill-publish  →  /skill-triager
-                    Option A                                                  Option D
-                    (this skill, front-gate)                                  (this skill, back-gate)
+/skill-sourcer  →  /skill-triager  →  /skill-creator  →  /skill-qa  →  /skill-publish  →  /skill-triager
+                    Option A                              (QA gate)                       Option D
+                    (this skill, front-gate)                                              (this skill, back-gate)
 ```
 
 This skill is the **only authorised path** to fire a `skill-build-request` dispatch to `zynkr-skill-builder`. Manual `gh api dispatches` calls are fine for one-offs but should be tracked back into the Project by hand.
@@ -151,6 +151,8 @@ Not happening.
 ### Option D — `confirm-ship`
 
 The artifact is **already built and committed** (typical for `/skill-publish` intakes). No scaffold is needed — just verify it landed correctly and close the loop in the Project.
+
+> **QA is pre-ship; confirm-ship is post-ship.** By the time you reach Option D the skill has *necessarily* passed QA — the PR could not have merged otherwise, because the `qa.yml` / `publish-skill.yml` QA check blocks any ERROR-tier skill. So Option D does **not** re-run QA; it trusts the merged PR's green QA check as the receipt and verifies the *live* artifact (the post-ship checks below).
 
 **Precondition:** `Built Skill URL` is set on the Project item, or the issue body has a `**Built Skill URL**:` line. If neither is present, tell the user "the SKILL.md hasn't been committed yet — commit to `zynkr-skill-builder`, then come back" and exit this option.
 

--- a/skills/6-engineer/zynkr/SKILL.md
+++ b/skills/6-engineer/zynkr/SKILL.md
@@ -32,6 +32,7 @@ Pattern-match the user's input against the table below. **First match wins.** He
 |---|---|
 | `https://github.com/<owner>/<repo>` or `https://skills.sh/...` referencing a SKILL.md or repo of skills | `external-skill-url` |
 | `https://github.com/peter-tu-zynkr/zynkr-skill-idea/issues/<N>` or `#<N>` referring to an idea-repo issue | `pipeline-issue-ref` |
+| User says "qa `<slug>`", "check this skill", "健檢", "does this pass QA", "review this skill" — OR drops a SKILL.md with an explicit QA/review verb | `qa-request` |
 | A folder path or file path that resolves to a `SKILL.md` on disk | `local-skill-md` |
 | `https://docs.google.com/document/...` | `google-doc` |
 | `.srt` / `.vtt` extension OR `youtu.be` / `youtube.com/watch` URL OR words like "transcript", "字幕", "逐字稿" | `transcript` |
@@ -54,7 +55,7 @@ For `external-skill-url`, `pipeline-issue-ref`, or `local-skill-md` inputs, gath
 |---|---|---|
 | GitHub Project | `gh project item-list 1 --owner peter-tu-zynkr --limit 200 --format json` — match by slug (derived from URL or frontmatter `name`) | Pipeline Status, Build Status, Keep, Intake Source, Built Skill URL |
 | Issue + labels | `gh issue list --repo peter-tu-zynkr/zynkr-skill-idea --search "<slug>" --json number,title,labels,state` | Existence of an issue, current label (`triage-ready` / `building` / `shipped` / `parked` / `rejected`), open vs closed |
-| On-disk SKILL.md | `ls "/Users/petertu/Desktop/Claude/zynkr/6.0 tech/zynkr-skill-builder/skills/<N-cat>/<slug>/SKILL.md"` | Whether scaffold or publish already landed in the repo |
+| On-disk SKILL.md | `ls skills/<N-cat>/<slug>/SKILL.md` (run from the repo root) | Whether scaffold or publish already landed in the repo |
 | Live `/api/skills` | `curl -sL https://www.zynkr.ai/api/skills` and grep for slug | Whether the skill is live on the marketplace |
 
 Pick the slug from either the URL last segment (`.../tree/main/skills/<slug>`) or the SKILL.md frontmatter `name`. If you can't resolve a slug, skip the state lookup and treat as `unclassified`.
@@ -72,11 +73,23 @@ Switch on `(input-type, state)` using the table below. Auto-invoke means use the
 | `external-skill-url`, no prior state | Invoke `/skill-sourcer <URL>` | High → auto |
 | `pipeline-issue-ref`, label = `triage-ready` | Invoke `/skill-triager` (cue Option A) | High → auto |
 | `pipeline-issue-ref`, label = `building`, on-disk file absent | Nudge: "Run `/skill-creator` on branch `skill/<slug>` to write the body" — don't auto-invoke; creator is human-in-the-loop interactive | High → nudge |
-| `local-skill-md`, slug matches an open `triage-ready` or `building` issue | Invoke `/skill-publish` (continuation mode) | High → auto |
-| `local-skill-md`, no matching open issue | Invoke `/skill-publish` (fresh-intake mode) | High → auto |
+| `local-skill-md`, slug matches an open `triage-ready` or `building` issue | Invoke `/skill-qa <path>` FIRST. On **PASS** → chain to `/skill-publish` (continuation mode). On **ERROR** → stop, surface the QA report, don't publish. On **WARN-only** → list warnings, ask "publish anyway?" then chain. | High → auto (QA → publish on PASS) |
+| `local-skill-md`, no matching open issue | Invoke `/skill-qa <path>` FIRST, then `/skill-publish` (fresh-intake mode) on PASS (same ERROR/WARN handling). | High → auto (QA → publish on PASS) |
 | `pipeline-issue-ref`, PR merged + slug on `/api/skills` + Project Build Status = `ready-to-ship` (or open issue still has `building` label) | Invoke `/skill-triager` (cue Option D `confirm-ship`) | High → auto |
 | `pipeline-issue-ref`, Project Pipeline Status = `shipped` | Render: "Already shipped — live at `https://www.zynkr.ai/ai-skills-marketplace` (slug `<slug>`). Nothing to do." | High → no-op |
 | `pipeline-issue-ref`, Project = `parked` / `rejected` | Render the state, ask if user wants to revive | Medium → ask |
+
+### QA inputs (standalone — any skill, any lifecycle stage)
+
+`/skill-qa` is also the on-demand health-check. Explicit QA intent never auto-publishes.
+
+| Input × State | Action | Confidence |
+|---|---|---|
+| `qa-request` + a local SKILL.md path or folder | Invoke `/skill-qa <path>` standalone; report the verdict. | High → auto |
+| `qa-request` + slug resolving to an in-pipeline `building` issue | Resolve the on-disk path (`skills/<N-cat>/<slug>/SKILL.md`) or the `skill/<slug>` branch head; invoke `/skill-qa`. | High → auto |
+| `qa-request` + slug of an already-`shipped` skill | Invoke `/skill-qa <slug>` against the in-tree `main` copy (re-audit / regression check). | High → auto |
+| `qa-request` + an `external-skill-url` / candidate not yet in the pipeline | Invoke `/skill-qa` on the fetched SKILL.md as a pre-intake quality probe. On PASS, offer: "Want to source this? → `/skill-sourcer`." | High → auto, then offer |
+| `qa-request` but no resolvable artifact | Ask once: "Point me at the SKILL.md (path, slug, or URL) to QA." | Medium → ask |
 
 ### Knowledge-pipeline inputs (broader Zynkr scope)
 
@@ -98,6 +111,7 @@ Switch on `(input-type, state)` using the table below. Auto-invoke means use the
 |---|---|
 | "What's in my triage queue?" / "show me triage-ready" | `gh issue list ... --label triage-ready` and render a table |
 | "Where is `<slug>`?" / "status of `<slug>`?" | Run the Step 2 four-signal lookup and render a one-screen state card |
+| "Does `<slug>` pass QA?" / "is `<slug>` QA-clean?" | Resolve the artifact (on-disk → branch → `main`), invoke `/skill-qa <slug>` in report-only mode, render the PASS/FAIL verdict card. Read-only — never publishes. |
 | "What shipped this week?" | `gh issue list ... --label shipped --search "closed:>2026-mm-dd"` and render |
 | "What's stuck?" / "what's in approved >7 days?" | Read Project, filter by `Pipeline Status=approved` AND age > 7 days, render |
 
@@ -121,6 +135,8 @@ When confidence is **High** and the action is `auto`:
 1. State your route in one sentence: "Routing to `/skill-publish` continuation against issue #84."
 2. Invoke the sub-skill via the **Skill** tool, passing the relevant input as `args`.
 3. Let the sub-skill drive from there. Don't re-implement its logic inline.
+
+**QA → publish chaining.** When the route is a finished `local-skill-md` for a build issue, invoke `/skill-qa` first and read its verdict. Only chain to `/skill-publish` on a **PASS** (zero ERROR-tier findings). On FAIL, print the QA report and stop — never publish an ERROR-tier skill from the router.
 
 ### Nudge
 


### PR DESCRIPTION
## What
Adds a **quality gate** to the skill pipeline — `/skill-sourcer → /skill-triager → /skill-creator → **/skill-qa** → /skill-publish` — enforced interactively (`/zynkr` front-door + `/skill-publish` Step 0) **and** in CI (non-bypassable). Implements Parts A–D of the approved plan; the skills.sh marketplace card (Part E) ships as a separate PR in `zynkr-website`.

## QA scope
- **Format**: frontmatter schema (reused), body H1 / install-snippet / summary / workflow section.
- **Downloadability**: absolute-path leak scan (`/Users`, `/home`, `C:\`), install-URL well-formed, source present (live check stays post-ship in `/skill-triager` Option D).
- **Sanity**: synergy slug existence, IPO length limits, attribution Case-C.

## Tiers (the key calibration)
`ERROR` blocks · `WARN` advises · `INFO` notes. I ran the engine against the **whole live catalog** before setting tiers: most internal skills don't follow SKILL_SPEC §2/§4 (install snippet + `## Step` body), so those are **WARN**. `ERROR` is limited to unambiguous breakage — schema failure, missing H1, machine-path leak. Blast radius = **3 skills with genuine bugs** (see below), not a third of the catalog. A **reference-entry escape hatch** + stub-awareness keep the pptx card and lift-and-shift skills (`find-skills`, `vercel-labs-agent-browser`) PASSing.

## Real bugs the engine surfaced (pre-existing, NOT fixed here except zynkr)
- `zynkr` — `/Users/...` leak in its Step 2 table → **fixed in this PR** (I was editing it anyway).
- `newsletter-to-notion`, `process-livestream` — real `/Users/petertu/...` paths in the body (won't work for any other user).
- `write-newsletter` — missing all required frontmatter (already fails today's validator).

These three only block a PR that *touches them* (the gate checks changed skills), so they don't block unrelated work — but they're worth fixing in a follow-up.

## Files
- `scripts/validate-skill.ts` — extended into the shared tiered engine (`--tier`, `--json`, `--github`); exports `SkillFrontmatter` + `TAXONOMY`. `scripts/package.json` gains a `qa` alias.
- `skills/6-engineer/skill-qa/SKILL.md` — new skill wrapping the engine (dogfoods clean: 0/0).
- `skills/6-engineer/{zynkr,skill-publish,skill-triager}/SKILL.md` — routing rows, Step 0 gate, pre/post-ship clarification.
- `.github/workflows/qa.yml` (new, `pull_request`→main) + extended `publish-skill.yml`, `pickup-approved-issue.yml`, `ingest-skills.yml`.

## Verified locally
- 3 reference fixtures PASS; a deliberately-broken fixture FAILs (exit 1, ERRORs on missing-H1 + leaked path).
- All 4 changed/new skills PASS (0 errors). `tsc --noEmit` clean. All 4 workflow YAMLs parse.

## ⚠️ Manual step after merge (makes it truly non-bypassable)
Make `qa.yml` a **required status check** on `main` (it must exist on main first, hence post-merge):
\`\`\`bash
gh api -X PUT repos/peter-tu-zynkr/zynkr-skill-builder/branches/main/protection \
  -H "Accept: application/vnd.github+json" \
  -f 'required_status_checks[strict]=true' \
  -f 'required_status_checks[checks][][context]=qa' \
  -F 'enforce_admins=false' \
  -f 'required_pull_request_reviews=' -F 'restrictions='
\`\`\`
(Adjust to taste — the key is requiring the `qa` check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)