### PR TITLE
feat(pipeline): confirm-ship offers local install (close publish↔invoke gap)

### DIFF
--- a/skills/6-engineer/skill-publish/SKILL.md
+++ b/skills/6-engineer/skill-publish/SKILL.md
@@ -261,7 +261,7 @@ Same `Pipeline Status` / `Build Status` two-track model as `/skill-sourcer`. Aft
 
 When you're done with `/skill-publish`, tell the user:
 
-> "Published via dispatch. PR opened (URL: <pr_url>). After the PR merges, run `/skill-triager` and pick **Option D — `confirm-ship`** on this issue to close the loop. The triager will run three read-only verifications (`gh api contents`, `skills-index.json`, `/api/skills`) before flipping `Pipeline Status=shipped`."
+> "Published via dispatch. PR opened (URL: <pr_url>). After the PR merges, run `/skill-triager` and pick **Option D — `confirm-ship`** on this issue to close the loop. The triager will run three read-only verifications (`gh api contents`, `skills-index.json`, `/api/skills`) before flipping `Pipeline Status=shipped`, then offer to install it into your local `~/.claude/skills/` via `npx skills add … --skill <slug>` — publishing to the marketplace alone does **not** make the skill invocable in your own Claude Code session."
 
 **Completion checklist (mode-dependent):**
 

--- a/skills/6-engineer/skill-triager/SKILL.md
+++ b/skills/6-engineer/skill-triager/SKILL.md
@@ -189,6 +189,11 @@ The artifact is **already built and committed** (typical for `/skill-publish` in
    gh issue close <num> --repo peter-tu-zynkr/zynkr-skill-idea \
      --comment "Triage decision: confirm-ship. Live at https://www.zynkr.ai/ai-skills-marketplace (slug: <slug>). Verified via gh contents + skills-index + /api/skills."
    ```
+8. **Offer to install it into the local runtime (author convenience — closes the publish↔invoke gap).** Shipping publishes the skill to the *marketplace*; it does **not** install it into your own `~/.claude/skills/`, so it is **not invocable in your Claude Code session** until added. Offer to run it now — use `npx skills add` (not the single-file `curl …/s/<id>.md` install) so multi-file skills bring their `references/` along:
+   ```bash
+   npx skills add https://github.com/peter-tu-zynkr/zynkr-skill-builder --skill <slug>
+   ```
+   On the user's OK, run it and confirm `~/.claude/skills/<slug>/SKILL.md` exists. Skip the offer for non-Claude skills (platform `gpt` / `gemini`) or if the user declines — the ship itself already succeeded regardless.
 
 **Why this is different from `assign-build`:** no `repository_dispatch` is fired — the in-tree SKILL.md is already picked up by `ingest-skills.yml` on push, so the marketplace card already exists by the time triage runs. Triage's job here is **bookkeeping + verification**, not orchestration.
 
@@ -231,6 +236,7 @@ When the session ends, summarise:
 - [ ] `Built Skill URL` backfilled if it was empty
 - [ ] Issue label `triage-ready` removed, `shipped` added
 - [ ] Issue closed with verification comment
+- [ ] Local install offered (`npx skills add … --skill <slug>`) — run on user OK, or skipped for non-Claude skills / on decline
 
 ---
 

--- a/skills/6-engineer/zynkr/SKILL.md
+++ b/skills/6-engineer/zynkr/SKILL.md
@@ -77,7 +77,7 @@ Switch on `(input-type, state)` using the table below. Auto-invoke means use the
 | `local-skill-md`, slug matches an open `triage-ready` or `building` issue | Invoke `/skill-qa <path>` FIRST. On **PASS** → chain to `/skill-publish` (continuation mode). On **ERROR** → stop, surface the QA report, don't publish. On **WARN-only** → list warnings, ask "publish anyway?" then chain. | High → auto (QA → publish on PASS) |
 | `local-skill-md`, no matching open issue | Invoke `/skill-qa <path>` FIRST, then `/skill-publish` (fresh-intake mode) on PASS (same ERROR/WARN handling). | High → auto (QA → publish on PASS) |
 | `pipeline-issue-ref`, PR merged + slug on `/api/skills` + Project Build Status = `ready-to-ship` (or open issue still has `building` label) | Invoke `/skill-triager` (cue Option D `confirm-ship`) | High → auto |
-| `pipeline-issue-ref`, Project Pipeline Status = `shipped` | Render: "Already shipped — live at `https://www.zynkr.ai/ai-skills-marketplace` (slug `<slug>`). Nothing to do." | High → no-op |
+| `pipeline-issue-ref`, Project Pipeline Status = `shipped` | Render: "Already shipped — live at `https://www.zynkr.ai/ai-skills-marketplace` (slug `<slug>`)." Then, if `~/.claude/skills/<slug>/` is absent, offer `npx skills add … --skill <slug>` so it's invocable locally (marketplace-live ≠ installed in your session). | High → no-op (offer local install if missing) |
 | `pipeline-issue-ref`, Project = `parked` / `rejected` | Render the state, ask if user wants to revive | Medium → ask |
 
 ### QA inputs (standalone — any skill, any lifecycle stage)


### PR DESCRIPTION
## Why
Publishing a skill lands it in git + marketplace/Supabase but **never installs it into the author's own `~/.claude/skills/`** — so a freshly-shipped skill (e.g. zynkr-slide) isn't invocable in the author's session until they manually `npx skills add`. This adds an explicit local-install step at the natural post-ship moment.

## Changes
- **skill-triager** Option D `confirm-ship` → new **step 8**: after the skill is verified live + the issue closed, offer `npx skills add … --skill <slug>` (npx, not the single-file `curl …/s/<id>.md`, so multi-file skills bring their `references/`); skip for non-Claude skills / on decline. + checklist item.
- **skill-publish** Step 7 hand-off message: note confirm-ship will offer the local install.
- **zynkr** router shipped route: offer the install if `~/.claude/skills/<slug>/` is absent.

QA: `validate-skill.ts --tier=all` on all 3 → 0 ERROR-tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)