### PR TITLE
update(zynkr-kms): core-facts model — canonical facts + citing entries

### DIFF
--- a/skills/3-operations/zynkr-kms/SKILL.md
+++ b/skills/3-operations/zynkr-kms/SKILL.md
@@ -149,21 +149,38 @@ saying so.
   This matters most for `pricing-quoting` and `refund-policy`, where stale answers are
   actively harmful.
 
-### Lens 3 — Structure for the LLM
-Render the entry exactly per `references/entry-schema.md`:
+### Lens 3 — Structure for the LLM (core fact vs. citing entry)
+The KB has **two block types** (full spec in `references/entry-schema.md`):
+
+- **Core Fact** (`### FACT:<id>`) — canonical, reusable truths whose *numbers/terms live here,
+  once*: the pricing table, refund policy, standard durations.
+- **Q&A entry** (`### Q:`) — maps one inquiry to the facts and **cites** them, rather than
+  restating the numbers.
+
+**Decide which you're writing.** If the answer rests on a fact that could appear in other
+answers or changes over time (price, rate, policy, lead time):
+1. Is there already a `FACT:<id>` for it? → the entry just adds `Cites: FACT:<id>` and
+   describes the *mapping/logic*, **no restated numbers**.
+2. No fact yet? → propose a **NEW FACT** block (numbers go there) **and** a thin citing entry.
+3. The fact exists but Peter's reply changes it (new rate)? → propose **UPDATE FACT** — one
+   edit, and every citing entry is current.
+
+Render exactly per `references/entry-schema.md`:
 
 ```
-### Q: <canonical, normalized question — phrased the way a future inquirer might ask>
+### Q: <canonical, normalized question>
 - Intent: <intent-tag>
-- Keywords: <zh-TW + EN synonyms / aliases that should retrieve this entry>
-- Answer: <Peter's answer, paraphrased into a clean statement; preserve exact facts verbatim (e.g. a quoted rate or fee)>
-- Source: <Gmail thread link> · <YYYY-MM-DD> · <first name / company>
+- Cites: <FACT:id…  — omit the line if it cites no fact>
+- Keywords: <zh-TW + EN synonyms / aliases>
+- Answer: <how this inquiry maps to the cited fact(s); the logic, not the restated numbers>
+- Source: <Gmail thread link> · <YYYY-MM-DD> · <provenance, e.g. "inbound 詢價">
 - Last verified: <YYYY-MM-DD>
 ```
 
-Keywords must be **bilingual** so an English inquiry still retrieves a zh-TW-sourced answer
-(and vice-versa). The drafter searches via `fullText contains`, so the keywords line is what
-makes an entry findable.
+Only inline a hard number when it is specific to this ticket and lives in **no** fact (then
+preserve it verbatim). Keywords must be **bilingual** — the drafter searches via
+`fullText contains` over the whole doc (so a citing entry still resolves to the fact's numbers
+at draft time), and the keywords line is what makes a block findable.
 
 ---
 
@@ -172,13 +189,14 @@ makes an entry findable.
 Present **one table** of everything you intend to write — nothing is written yet:
 
 ```
-Proposed KB entries from N resolved threads:
+Proposed KB changes from N resolved threads:
 
-| # | Action | Intent | Section | Entry preview | Flag |
-|---|--------|--------|---------|---------------|------|
-| 1 | NEW    | pricing-quoting | Pricing & Quoting | Q: 一天六小時的 AI 課程怎麼報價？ … | — |
-| 2 | UPDATE | pricing-quoting | Pricing & Quoting | supersedes the older NT$X entry | ⚠ pricing change |
-| 3 | NEW (new category) | logistics-overseas | (creates section) | … | ⚠ new category |
+| # | Action | Target | Section | Preview | Flag |
+|---|--------|--------|---------|---------|------|
+| 1 | UPDATE FACT | FACT:pricing-rates | Core Facts | 實體 rate → NT$Y | ⚠ pricing change |
+| 2 | NEW entry   | Q (pricing-quoting) | Pricing & Quoting | Cites FACT:pricing-rates | — |
+| 3 | NEW FACT    | FACT:refund-policy | Core Facts | (creates canonical fact) | ⚠ new fact |
+| 4 | NEW (new category) | Q (logistics-overseas) | (creates section) | … | ⚠ new category |
 ```
 
 Then show the **full rendered block** for each proposed entry below the table.
@@ -211,16 +229,26 @@ If he rejects a thread entirely, do not label it ingested (Step 6).
 section in the template ends with an invisible marker line; you replace the marker with your
 entry **plus the marker again**, so it stays appendable:
 
+- **NEW Core Fact** — `mcp__google-workspace__find_and_replace_doc`:
+  - `find_text`: `<!-- ▼APPEND:core-facts▼ -->`
+  - `replace_text`: `<rendered FACT block>\n\n<!-- ▼APPEND:core-facts▼ -->`
+- **UPDATE a Core Fact** (the high-value path — one edit refreshes every citing entry) —
+  `find_and_replace_doc` on the specific changed line(s) inside the fact (e.g. a rate row), or
+  on the whole `### FACT:<id> …` block if it's been restructured. Bump its `Last verified`.
 - **NEW entry into an existing section** — `mcp__google-workspace__find_and_replace_doc`:
   - `find_text`: `<!-- ▼APPEND:<intent>▼ -->`
   - `replace_text`: `<rendered entry block>\n\n<!-- ▼APPEND:<intent>▼ -->`
-- **UPDATE / supersede** — `find_and_replace_doc`:
+- **UPDATE / supersede an entry** — `find_and_replace_doc`:
   - `find_text`: the old entry's unique `### Q: …` block (enough lines to be unique)
   - `replace_text`: the new block (bump `Last verified`)
 - **NEW section** (intent has no section yet) — `find_and_replace_doc`:
   - `find_text`: `<!-- ▼NEW-SECTIONS▼ -->`
   - `replace_text`: `## <Section Title>\n\n<!-- ▼APPEND:<intent>▼ -->\n\n<!-- ▼NEW-SECTIONS▼ -->`
     then do the NEW-entry replace into the just-created `▼APPEND:<intent>▼` marker.
+
+> **Order:** write/UPDATE the **FACT first**, then the citing entry — so the cited `FACT:<id>`
+> already exists when the entry references it. Multi-line `find_text` can be unreliable across
+> paragraph breaks; prefer replacing one unique line at a time.
 
 If a `find_and_replace_doc` ever reports 0 replacements (marker drift), fall back to
 `mcp__google-workspace__inspect_doc_structure` to get `total_length`, then
@@ -266,8 +294,11 @@ becomes a first-class category next time.
   the thread. Holding replies teach nothing — skip them.
 - **One source of truth.** The Google Doc is canonical. Don't create a second KB doc; always
   find-or-create the single `Zynkr Support KB`.
-- **Supersede, don't pile up.** Especially for pricing/policy — an UPDATE that replaces the
-  stale block is better than two contradictory entries the drafter might both retrieve.
+- **Canonical numbers live once.** Pricing/policy/rates go in a `### FACT:<id>` in Core Facts;
+  Q&A entries **cite** the fact (`Cites: FACT:<id>`) instead of restating it. Update the fact
+  in one place rather than chasing the same number across entries.
+- **Supersede, don't pile up.** Especially for facts — an UPDATE to the canonical FACT beats
+  two contradictory blocks the drafter might both retrieve.
 - **PII never lands in the KB** — first name + company only.
 - **Idempotency is the label.** A thread carrying `KMS-ingested` is done; never re-write it.
   A skipped thread stays un-labelled on purpose so it's reconsidered once truly answered.

--- a/skills/3-operations/zynkr-kms/references/entry-schema.md
+++ b/skills/3-operations/zynkr-kms/references/entry-schema.md
@@ -1,63 +1,113 @@
 # Entry Schema — Zynkr Support KB
 
-Every learned Q&A is rendered as one block in this exact shape. Consistency is what makes the
-KB both human-skimmable and reliably retrievable by `support-reply-drafter`'s `fullText`
-search.
+The KB holds **two kinds of blocks**, and keeping them distinct is the whole point:
 
-## The block
+1. **Core Facts** (`### FACT:<id>`) — canonical, reusable truths that many answers depend on:
+   the pricing table, refund policy, standard durations. **The numbers live here, once.**
+2. **Q&A entries** (`### Q:`) — one per resolved ticket. They map an inquiry to the facts and
+   **cite** them via a `Cites:` line instead of restating the numbers.
+
+Why split them: a price or policy that's copied into ten answers drifts the moment it
+changes. Put it in one FACT, have entries cite it, and a single edit updates every answer.
+The drafter reads the whole doc in one fetch, so a citing entry still resolves to the real
+numbers at draft time.
+
+> **Rule of thumb:** if a fact could appear in more than one answer, or is the kind of thing
+> that changes over time (price, rate, policy, lead time) — it belongs in a **FACT**, and
+> entries **cite** it. Don't restate cited numbers inside an entry's Answer.
+
+---
+
+## Block type 1 — Core Fact
+
+```
+### FACT:<id> · <human title>
+<the canonical fact — a short table and/or bullet list; the actual numbers/terms>
+- Keywords: <zh-TW + EN terms that should retrieve this fact>
+- Last verified: <YYYY-MM-DD>
+```
+
+- **`FACT:<id>`** — stable, kebab-case, unique (e.g. `pricing-rates`, `refund-policy`,
+  `standard-durations`). Entries reference it verbatim, so don't rename casually.
+- Put the **authoritative numbers/terms here and nowhere else.** Include a worked example in
+  the fact if it helps (e.g. "一天 6 小時 → …").
+- Note any **undefined scope** explicitly ("實體是否含交通費 — 尚未定義") so it isn't silently
+  assumed.
+- Facts live in the **`## Core Facts`** section (anchor `<!-- ▼APPEND:core-facts▼ -->`).
+
+## Block type 2 — Q&A entry
 
 ```
 ### Q: <canonical, normalized question>
 - Intent: <intent-tag from intent-taxonomy.md>
-- Keywords: <zh-TW term, EN term, synonym, synonym…>
-- Answer: <Peter's answer as a clean statement; exact facts preserved verbatim>
-- Source: <Gmail thread link> · <YYYY-MM-DD> · <first name / company>
+- Cites: <FACT:id, FACT:id…  — omit the line entirely if the answer cites no fact>
+- Keywords: <zh-TW term, EN term, synonym…>
+- Answer: <how this inquiry maps to the cited fact(s); the logic, not the restated numbers>
+- Source: <Gmail thread link> · <YYYY-MM-DD> · <provenance, e.g. "inbound 詢價">
 - Last verified: <YYYY-MM-DD>
 ```
 
 ## Field rules
 
-- **Q (the heading)** — Normalize to how a *future* inquirer would ask, not the exact words of
-  this one. Strip names, pleasantries, and one-off specifics. Good: `一天六小時的 AI 課程如何
-  報價？`. Bad: `回覆<某某>：你問的報價`. The `### Q:` prefix makes each entry a unique,
-  find-and-replaceable anchor.
+- **Q (the heading)** — Normalize to how a *future* inquirer would ask, not this one's exact
+  words. Strip names, pleasantries, one-off specifics. Good: `一天 N 小時的 AI 課程如何報價？`.
+  Bad: `回覆<某某>：你問的報價`. The `### Q:` / `### FACT:` prefix is the unique
+  find-and-replace anchor.
 - **Intent** — exactly one tag from `intent-taxonomy.md`.
-- **Keywords** — bilingual, comma-separated. Include the words an inquirer would actually type
-  in either language. This line is the retrieval surface; spend effort here.
-- **Answer** — Paraphrase into a clean, reusable statement, but **preserve hard facts
-  verbatim**: prices (`線上 NT$<rate>/hr、實體 NT$<rate>/hr`), durations, named steps, policy
-  terms. Never round, soften, or extrapolate. If Peter only answered part of the question, the
-  Answer covers only that part (and the proposal flags the gap).
-- **Source** — thread permalink + the date Peter answered + first name / company only. **No
-  email, no phone, no full names of individuals beyond a first name.**
-- **Last verified** — the date this entry was written or last confirmed current. The future
-  staleness job (per the Build Plan) keys off this.
+- **Cites** — zero or more `FACT:<id>` references. If the answer leans on a canonical fact
+  (pricing, policy…), **cite it instead of restating the numbers.** If the needed fact doesn't
+  exist yet, propose creating it (a new FACT block) in the same approval round.
+- **Keywords** — bilingual, comma-separated. The retrieval surface — spend effort here.
+- **Answer** — the *mapping/logic*: how this inquiry resolves against the cited facts ("依
+  FACT:pricing-rates，依時數計價、人數不加價"). Only inline a hard number when it is **specific
+  to this ticket and not in any fact** (then preserve it verbatim — never round or extrapolate).
+  If Peter answered only part of the question, cover only that part and flag the gap.
+- **Source** — thread permalink + date + lightweight provenance. **No customer PII beyond a
+  first name + company; prefer a generic tag like "inbound 詢價" when the identity adds nothing.**
+- **Last verified** — date written or last confirmed current. The staleness job keys off this.
 
 ## Mapping to the future `kb_articles` table
 
-When the KB graduates to Supabase pgvector (per `Zynkr KMS — Build Plan`), each block ports
-1:1 — so keep the shape stable:
+When the KB graduates to Supabase pgvector (per `Zynkr KMS — Build Plan`), both block types
+port cleanly — keep the shapes stable:
 
 | Doc field | `kb_articles` column |
 |---|---|
-| `Q:` heading | `title` |
-| `Answer:` | `body_md` |
+| `Q:` / `FACT:` heading | `title` |
+| `Answer:` / fact body | `body_md` |
 | `Intent:` + `Keywords:` | `tags[]` |
+| `Cites:` | `tags[]` (or a future `kb_edges` cite-graph) |
 | `Source:` link | `source_url` |
-| Source date / origin | `source_type = peter_answer`, `created_at` |
+| Source date / origin | `source_type` (`peter_answer` / `core_fact`), `created_at` |
 | `Last verified:` | `last_verified_at` |
 
-## Worked example
+A FACT is just an article with `source_type=core_fact`; the `Cites:` line is the seed of a
+cite-graph the RAG layer can traverse.
+
+## Worked example — a fact + an entry that cites it
 
 ```
-### Q: 一天 <N> 小時的 AI 課程怎麼報價？人數會影響價格嗎？
-- Intent: pricing-quoting
-- Keywords: 報價, 費用, 鐘點, 人數, 線上, 實體, pricing, quote, day rate, per hour, headcount, online, in-person
-- Answer: 授課依時數計價：線上每小時 NT$<rate_online>、實體每小時 NT$<rate_onsite>。一天 <N> 小時即線上 NT$<subtotal_online>、實體 NT$<subtotal_onsite>。<min>–<max> 人皆適用同一費率，不另依人數加價。（實體是否含交通／場地／教材費，依實際回覆而定。）
-- Source: <gmail-thread-link> · <YYYY-MM-DD> · <first-name / company>
+### FACT:pricing-rates · 授課費率表
+| 模式 | 每小時費率 |
+| 線上 online | NT$<rate_online> |
+| 實體 in-person | NT$<rate_onsite> |
+- 計價方式：依實際授課時數計價（per hour）。
+- 人數：單一費率，不依人數加價（headcount-independent）。
+- 範例：一天 6 小時 → 線上 NT$<subtotal_online>、實體 NT$<subtotal_onsite>。
+- 未定範圍：實體是否含交通／場地／教材費 — 尚未定義。
+- Keywords: 報價, 費用, 價格, 鐘點, 費率, 線上, 實體, pricing, rate, per hour, online, in-person
 - Last verified: <YYYY-MM-DD>
 ```
 
-> The placeholders above (`<rate_online>`, `<first-name / company>`, …) are illustrative —
-> a real entry fills them with the exact facts Peter wrote, with PII reduced to first name +
-> company per the guardrails.
+```
+### Q: 一天 N 小時的 AI 課程怎麼報價？人數會影響價格嗎？
+- Intent: pricing-quoting
+- Cites: FACT:pricing-rates
+- Keywords: 報價, 費用, 一天幾小時, 人數, 團隊訓練, quote, day rate, headcount
+- Answer: 依 FACT:pricing-rates 報價 — 依實際時數計價、線上／實體費率不同、人數不加價；用客戶需要的時數 × 對應費率即為報價（一天 6 小時的範例見費率表）。
+- Source: <gmail-thread-link> · <YYYY-MM-DD> · inbound 詢價
+- Last verified: <YYYY-MM-DD>
+```
+
+> Placeholders (`<rate_online>`, …) are illustrative — a real fact fills them with the exact
+> figures Peter stated. Note the entry carries **no NT$ numbers**: they live only in the fact.

--- a/skills/3-operations/zynkr-kms/references/kb-doc-template.md
+++ b/skills/3-operations/zynkr-kms/references/kb-doc-template.md
@@ -11,6 +11,10 @@ Each section ends with an anchor line `<!-- ▼APPEND:<intent>▼ -->`. To add a
 the same anchor (so it stays at the bottom of the section for next time). The single
 `<!-- ▼NEW-SECTIONS▼ -->` at the very end is where brand-new sections get inserted.
 
+The **`## Core Facts`** section sits first and holds canonical `### FACT:<id>` blocks (pricing,
+policy…) via its own `<!-- ▼APPEND:core-facts▼ -->` anchor. Q&A entries below **cite** these
+facts (`Cites: FACT:<id>`) instead of restating numbers — see `entry-schema.md`.
+
 > These anchor lines are intentionally visible plain text in the Doc — they're harmless
 > markers and they make appends index-free. Don't delete them.
 
@@ -26,8 +30,15 @@ support-reply-drafter reads to draft replies. Each entry is one resolved Q&A.
 Do not hand-edit the ▼ anchor lines — the skill uses them to append/update.
 
 Owner: Peter Tu (peter_tu@zynkr.ai)
-Conventions: one entry per resolved ticket · facts preserved verbatim · zh-TW default,
-bilingual keywords · supersede stale answers rather than duplicating.
+Conventions: canonical numbers live once in Core Facts · Q&A entries cite facts, don't restate them
+· zh-TW default, bilingual keywords · supersede stale facts rather than duplicating.
+
+========================================================================
+
+## Core Facts
+> Canonical facts = the single source of truth. Q&A entries cite these by ID (Cites:) instead of restating them, so updating a fact here updates every answer that depends on it.
+
+<!-- ▼APPEND:core-facts▼ -->
 
 ========================================================================
 
@@ -88,6 +99,7 @@ bilingual keywords · supersede stale answers rather than duplicating.
 
 | Section title | anchor intent tag |
 |---|---|
+| Core Facts | `core-facts` (holds `FACT:<id>` blocks, not Q&A) |
 | Pricing & Quoting | `pricing-quoting` |
 | Course Content & Curriculum | `course-content` |
 | Scheduling & Logistics | `scheduling-logistics` |


### PR DESCRIPTION
Evolves the zynkr-kms KB schema to a **core-facts** model: canonical numbers (pricing, policy) live once in a `## Core Facts` section as `### FACT:<id>` blocks; Q&A entries `Cites:` them instead of restating — killing pricing drift. Mirrors a restructure already applied to the live KB Doc. Relates to peter-tu-zynkr/zynkr-skill-idea#105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)