### PR TITLE
feat(training-process-video): 移植營運實戰更新（名單上傳、Kit 訂閱、電子報式回顧）

### DIFF
--- a/skills/4-training/training-process-video/SKILL.md
+++ b/skills/4-training/training-process-video/SKILL.md
@@ -48,6 +48,9 @@ After selection:
   - `chapter_prefix`: prefix used for chapter files (e.g., `claude-code-ops`)
   - `chapter_count`: total number of chapter files
   - `recap_folder_id`: Google Drive folder ID for recap uploads
+  - `roster_folder_id`: Google Drive folder ID for participant roster Sheets (`TODO` = skip Gate F)
+  - `roster_input_folder_id`: Google Drive folder ID where a shortcut to the roster Sheet is created for GAS aggregation (`TODO` = skip shortcut creation)
+  - `kit_tag_prefix`: Kit tag prefix for this stream, e.g. `[4] Claude Code` (`TODO` = skip Gate F.5)
   - All Google Doc/Sheet IDs listed in the Google Workspace Sync Map section of the config
 
 Display: `✅ 已載入串流設定：[selected stream folder name]`
@@ -468,6 +471,136 @@ Wait for user input.
 
 ---
 
+## Step 9.6 — Gate F: Participant roster upload
+
+> This step handles the `.xlsx` participant roster downloaded from the event platform (e.g. Accupass/活動通). Accupass has no API — the user downloads the file manually and provides the path.
+
+Read `roster_folder_id` from `stream-config.md`. If it is `TODO`, skip this gate, set `ROSTER_STATUS` to "略過（未設定 roster_folder_id）" and proceed to Step 9.7.
+
+If no participant list path was provided in Step 1, ask:
+```
+─────────────────────────────────────────
+Gate F — 參加名單歸檔
+─────────────────────────────────────────
+請提供活動平台下載的 .xlsx 檔案路徑：
+（輸入路徑，或按 Enter 略過）
+─────────────────────────────────────────
+```
+
+If user skips (empty Enter), set `ROSTER_STATUS` to "略過" and proceed to Step 9.7.
+
+Otherwise, show:
+```
+─────────────────────────────────────────
+Gate F — 參加名單歸檔
+─────────────────────────────────────────
+來源檔案：[xlsx 路徑]
+上傳目標：[活動名稱]_[YYYY.M.DD]（Google Sheet）
+目標資料夾：[roster_folder_id 對應資料夾]
+[若 roster_input_folder_id 已設定] 同時建立捷徑至 input 資料夾（供 GAS 更新總表用）
+
+[Y] 確認上傳
+[N] 略過
+─────────────────────────────────────────
+```
+
+**[Y] — execute (use Python + Drive API; MCP has no xlsx→Sheet conversion tool):**
+
+1. Upload the xlsx and convert it to a Google Sheet in the `roster_folder_id` folder:
+   ```python
+   from googleapiclient.http import MediaFileUpload
+   media = MediaFileUpload(xlsx_path,
+       mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+       resumable=True)
+   file_meta = {
+       'name': '[活動名稱]_[YYYY.M.DD]',
+       'mimeType': 'application/vnd.google-apps.spreadsheet',
+       'parents': ['[roster_folder_id]']
+   }
+   sheet = drive_service.files().create(body=file_meta, media_body=media, fields='id,webViewLink').execute()
+   SHEET_ID = sheet['id']
+   ```
+
+2. If `roster_input_folder_id` in `stream-config.md` is not `TODO`, create a shortcut in that input folder (one per event):
+   ```python
+   shortcut_meta = {
+       'name': '[活動名稱]_[YYYY.M.DD]',
+       'mimeType': 'application/vnd.google-apps.shortcut',
+       'shortcutDetails': {'targetId': SHEET_ID},
+       'parents': ['[roster_input_folder_id]']
+   }
+   drive_service.files().create(body=shortcut_meta, fields='id').execute()
+   ```
+
+3. Set `ROSTER_STATUS` to "✅ 已上傳並建立捷徑"
+
+Show:
+```
+✅ 參加名單已上傳為 Google Sheet：[webViewLink]
+✅ 捷徑已建立至 input 資料夾（供 GAS 使用）
+```
+
+**[N]**: Set `ROSTER_STATUS` to "略過"
+
+---
+
+## Step 9.7 — Gate F.5: Upload subscribers to Kit
+
+If `ROSTER_STATUS` is "略過" (Gate F was skipped), skip this gate and set `KIT_STATUS` to "略過".
+
+Read `kit_tag_prefix` from `stream-config.md` (e.g. `[4] Claude Code`). If it is `TODO`, skip this gate and set `KIT_STATUS` to "略過（未設定 kit_tag_prefix）".
+
+Otherwise, display:
+
+```
+─────────────────────────────────────────
+Gate F.5 — 上傳訂閱者至 Kit
+─────────────────────────────────────────
+來源：參加名單 Google Sheet（[SHEET_ID]）
+動作：新增至 Kit 訂閱者列表 + 打上活動標籤
+
+[Y] 確認執行
+[N] 略過
+─────────────────────────────────────────
+```
+
+**[N]**: Set `KIT_STATUS` to "略過", proceed to Step 10.
+
+**[Y] — execute:**
+
+**1. Read the roster**
+Read `SHEET_ID` with `mcp__google-workspace__get_drive_file_content` to get the CSV content.
+
+Column mapping (Accupass format):
+- Column index 2: 訂購人姓名 → Kit `first_name`
+- Column index 3: 訂購人Email → Kit `email_address`
+
+**2. Clean the data**
+- Dedupe: keep the first row per email
+- Filter: skip emails containing `privaterelay.appleid.com` (Apple private relay — undeliverable)
+
+Display the cleaning result: 原始 N 筆 → 去重 X 筆 → 過濾 Y 筆 → 有效 Z 筆
+
+**3. Resolve the Kit tag**
+Use `mcp__kit__list_tags` to find the highest number among tags sharing the `kit_tag_prefix`, then +1 for the new tag number. Create it with `mcp__kit__create_tag` (returns the existing ID if the tag already exists).
+
+**4. Bulk-create subscribers**
+Call `mcp__kit__bulk_create_subscribers` in batches of ≤100 (upsert — existing subscribers are updated automatically).
+Collect every valid `subscriber_id` — including those returned inside "Cannot override state" failure items. Those subscribers already exist and must still be tagged, otherwise they are silently missed.
+
+**5. Bulk-tag subscribers**
+Call `mcp__kit__bulk_tag_subscribers` in batches of ≤100 with the tag from step 3.
+
+Set `KIT_STATUS` to "✅ [N] 筆已上傳，標籤：[tag_name]"
+
+Show:
+```
+✅ Kit 訂閱者已更新：[N] 筆成功 | [M] 筆失敗
+🏷 標籤：[tag_name]（ID: [tag_id]）
+```
+
+---
+
 ## Step 10 — Final summary and file archival
 
 Display:
@@ -494,6 +627,12 @@ Stream : [title] ([date])
 💡 內容點子
    寫入：[N] 個 seed → _matrix.md  |  略過：[M] 個
    ☁️ Google Sync：[成功/略過/失敗]
+
+📋 參加名單
+   [ROSTER_STATUS]
+
+📧 Kit 訂閱者
+   [KIT_STATUS]
 
 ─────────────────────────────────────────
 ```

--- a/skills/4-training/training-process-video/agents/training-event-recap.md
+++ b/skills/4-training/training-process-video/agents/training-event-recap.md
@@ -56,12 +56,16 @@ Segment the cleaned transcript into logical blocks:
 
 From the segmented transcript, extract:
 
-1. **Executive summary** — 2–3 sentences capturing the session's purpose and main outcome
-2. **Theme** — single sentence naming the central topic or thesis of this session
-3. **Key insights** — 3–5 standalone takeaways, each with a short explanation (2–4 sentences)
-4. **Q&A pairs** — extract each attendee question and the lecturer's answer as an explicit pair; if questions were not asked aloud, extract the implied question from context
-5. **Tools & Resources** — list tools mentioned first (with brief description), then links, files, or other references
-6. **Call to action** — attendee-facing next steps: what should participants do after this session; include deadline or owner if mentioned, else "自行安排"
+1. **Subtitle** — one punchy line capturing the session's central thesis (e.g. "從『用 AI』，到『讓 AI 幫你做事』")
+2. **Opening message** — 2–3 short sentences from the speaker's perspective thanking attendees and naming the one thing that was demonstrated (not a bullet list — natural prose)
+3. **Main sections** — 3–5 numbered sections (一、二、三…). Each section has:
+   - A heading that names the topic
+   - 2–5 short bullet points or lines. Use 👉 to introduce the most important single point in the section.
+   - Keep each section under 80 words
+4. **Call to action** — 2–3 lines listing what attendees can do next (join community, book consultation, fill survey, etc.). Use the actual links or instructions mentioned in the transcript.
+5. **Closing** — 1–2 lines of warm personal sign-off from the speaker, including the speaker's first name.
+
+Follow the tone rules in `references/recap-article-template.md` (first-person speaker voice, 昨晚 not 今晚, no Q&A/tools/resources sections, 👉 once per section at most).
 
 ---
 
@@ -80,10 +84,10 @@ Return a single structured result block to the manager:
 ```
 AGENT: training-event-recap
 STATUS: complete
-DOC_TITLE: [proposed document title: "[Stream Title] — 直播回顧 [YYYY-MM-DD]"]
+DOC_TITLE: [proposed document title: "[Stream Title] 直播筆記 [YYYY-MM-DD]"]
 SUMMARY: [1-paragraph plain text summary of what was captured]
 CONTENT:
-[full formatted recap article, ready to paste into Google Docs]
+[full formatted newsletter-style recap, ready to paste into Google Docs]
 ```
 
 If formatting fails (e.g. template cannot be applied), return:

--- a/skills/4-training/training-process-video/references/recap-article-template.md
+++ b/skills/4-training/training-process-video/references/recap-article-template.md
@@ -2,73 +2,46 @@
 
 Use this template when creating the Google Doc event recap. Fill every section from the transcript. Do not invent content.
 
----
-
-# [Stream Title] — 直播回顧
-
-**日期：** [YYYY-MM-DD]
-**主題：** [One-sentence theme — the central topic or thesis of this session]
+The recap is a **newsletter-style message** written in first person from the speaker's perspective — like a newsletter or LINE message to attendees, not an academic article or meeting minutes.
 
 ---
 
-## 本場重點摘要
+```
+[Stream Title]
+[Subtitle — one punchy line capturing the session's central thesis]
 
-> [2–3 sentence executive summary for readers who only read the top]
+[Opening message — 2–3 short sentences from the speaker's perspective thanking attendees and naming the one thing that was demonstrated. Natural prose, not a bullet list.]
 
----
+________________
 
-## 核心洞察
+一、[Section title — names the topic]
+[2–5 short bullet points or lines. Use 👉 to introduce the most important single point in the section. Keep the section under 80 words.]
+________________
 
-List 3–5 key insights from the stream. Each insight is a standalone takeaway.
+二、[Section title]
+[content]
+________________
 
-### 1. [Insight title]
-[2–4 sentences expanding on the insight. Quote the speaker directly if possible.]
+（continue for all sections — 3–5 numbered sections total）
 
-### 2. [Insight title]
-[2–4 sentences]
+________________
 
-### 3. [Insight title]
-[2–4 sentences]
+[Call to action — 2–3 lines listing what attendees can do next (join community, book consultation, fill survey, etc.). Use the actual links or instructions mentioned in the transcript.]
 
-*(Add more as needed)*
+________________
 
----
-
-## 學員問答
-
-Capture each attendee question and the lecturer's answer as an explicit pair. If a question was implied rather than asked aloud, state it as the implied question.
-
-**Q：** [Attendee question]
-**A：** [Lecturer's answer — summarise faithfully, keep key terms]
-
-**Q：** [Attendee question]
-**A：** [Lecturer's answer]
-
-*(Add more as needed; use "無" if no Q&A occurred)*
+[Closing — 1–2 lines of warm personal sign-off from the speaker]
+[Speaker first name]
+```
 
 ---
 
-## 工具與資源
+## Tone rules
 
-List tools mentioned during the stream first, then other links, files, or references.
-
-**工具：**
-- **[Tool name]** — [One-line description of what it does / how it was used]
-
-**其他資源：**
-- [Resource name or description]
-
----
-
-## 課後行動
-
-Attendee-facing next steps after this session. Include deadline or owner if mentioned.
-
-| 行動項目 | 負責人 | 預計完成 |
-|----------|--------|----------|
-| [Action] | [Name or 自行安排] | [Date or 自行安排] |
-| [Action] | [Name or 自行安排] | [Date or 自行安排] |
-
----
-
-*本文由 Claude Code 自動從直播逐字稿整理，僅供參考。如有錯誤請直接修改本文件。*
+- Write in first person from the speaker's perspective, addressed to 大家
+- Conversational and direct — like a newsletter or LINE message, not an academic article
+- No Q&A section, no tools list, no resources table
+- Use 👉 sparingly (once per section at most) for the key takeaway line
+- Time references: use **昨晚** (not 今晚) — the recap is posted the day after the event
+- Opening message: if there is a guest speaker, refer to them by name (e.g. "我跟 Ernie 都走過..."), NOT by the host's own name
+- Each numbered section should have a subtitle after the number (e.g. 一、這次講座的主題)


### PR DESCRIPTION
## 摘要

把營運端（Jane）過去八場直播實戰迭代出的更新，移植回 training-process-video。所有新增步驟都遵循 stream-config 架構（欄位未設定即自動跳過），不影響現有使用方式。

## 變更內容

### 1. New Gate F — Participant roster upload (`SKILL.md`)
Uploads the Accupass `.xlsx` roster as a Google Sheet to the stream's Drive folder, and optionally creates a shortcut in a GAS input folder for master-sheet aggregation. Driven by two new `stream-config.md` fields: `roster_folder_id`, `roster_input_folder_id` (`TODO` = skip).

### 2. New Gate F.5 — Kit subscriber upload (`SKILL.md`)
Reads the roster Sheet, cleans the data (dedupe by email, filter Apple private-relay addresses), resolves the stream's Kit tag from the new `kit_tag_prefix` config field, then bulk-creates and bulk-tags subscribers in batches of ≤100.

Includes a field lesson from May: Kit `bulk_create_subscribers` items that fail with "Cannot override state" still carry valid `subscriber_id`s — those subscribers already exist and must still be tagged, otherwise they are silently missed.

### 3. Event recap switched to newsletter style (`agents/training-event-recap.md`, `references/recap-article-template.md`)
The recap format evolved over 8+ live sessions from a meeting-minutes layout (executive summary / Q&A / tools table) to a newsletter-style message in the speaker's first-person voice: subtitle, opening message, 3–5 numbered sections with 👉 key takeaways, CTA, and personal sign-off. Tone rules (昨晚 not 今晚, guest-speaker naming, etc.) live in the template so future format tweaks only touch one file.

## 沒有動的部分

- 各檔案 frontmatter（sheetId 4.02/4.06）與 catalog metadata
- `generated/`、`content/` 自動產生檔（由 auto-ingest 重生）
- QA agent 的 MECE health check 與 stream-config 架構（營運端已同步採用 MECE 檢查）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
