### PR TITLE
feat(sales-consultant): sales-follow-up skill (post-demo conversion follow-up)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,3 +44,29 @@ Local zh-TW runtime copies in `~/.claude/skills/` updated in the same session
 **Verification**: S-sized docs change · references/*.md only (no SKILL.md → PR-QA
 n/a) · ingest backstop expected green on push (re-emits content/, no slug/sheetId
 changes).
+
+## 2026-07-03 — new skill: sales-follow-up (post-demo conversion follow-up)
+
+`sales-follow-up` (sheetId `2.10`, category `2-sales-consultant`) — the post-demo
+counterpart to `sales-outbound`. From one completed demo transcript it (1) drafts a
+threaded pre-sales follow-up as a Gmail DRAFT in Peter's voice — leading with the
+prospect's own pain points, mapping each to the matching `zynkr.ai/ai-platform`
+capability, converting toward adoption; and (2) light-syncs the EXISTING CRM deal —
+logs the demo as a `note`, refreshes the deal summary, nudges the stage only if
+earned, closes the stale scheduling task, and books the agreed follow-up task.
+Bundles `references/demo-note.sql` (the single raw-SQL write, since the Zynkr MCP has
+no create-note tool; author/contact/company resolved live from the deal). Captured
+from a real run (超哥 / 行銷超哥 Chao.Marketing demo). Installed to the
+`~/.claude/skills/` runtime in the same session (edit-BOTH rule) so `/sales-follow-up`
+is invocable immediately.
+
+Deliberately does NOT log the follow-up email as an activity — the Gmail→CRM sync
+captures it on send; logging here would duplicate the row (same rule as
+`sales-outbound`).
+
+**Verification**: M-sized skill-content add · `validate-skill.ts --tier=all` → 0
+errors, 0 warnings (IPO frontmatter tightened under truncation caps) · `ingest.ts`
+dry-run exit 0, sheetId `2.10` confirmed free (no duplicate throw) · `qa.yml` fires on
+the new `skills/**/SKILL.md` in the PR (D0/D1 mechanical) · local install verified
+(skill appears in the session's available-skills list) · live-trigger (D2 `/verify`)
+deferred to Peter's first real use per build-and-review scope.

--- a/skills/2-sales-consultant/sales-follow-up/SKILL.md
+++ b/skills/2-sales-consultant/sales-follow-up/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: sales-follow-up
+description: >-
+  Turn a finished sales DEMO / discovery call into a converting follow-up — the
+  post-meeting counterpart to sales-outbound. Give it the demo transcript (a
+  Google Doc URL or pasted notes) and it does two things in one pass: (1) drafts
+  a pre-sales follow-up reply as a threaded Gmail DRAFT in Peter's inbox (never
+  sends), in the prospect's language and Peter's voice — opening by mirroring the
+  exact pain points they raised, mapping each to the matching Zynkr AI 平台
+  capability (zynkr.ai/ai-platform), and moving them toward adopting the
+  solution, with a "sales kit attached manually" line; (2) syncs the EXISTING
+  CRM deal — finds the deal / contact / company, logs the demo as a note
+  activity, refreshes the deal summary, nudges the stage if warranted, closes the
+  now-stale scheduling task, and creates the agreed follow-up task. Trigger on
+  /sales-follow-up or when Peter hands over a demo / meeting transcript after a
+  call and says "draft a follow-up", "draft the pre-sales follow-up", "follow up
+  on this demo", "寫跟進信", "擬一封 demo 後的跟進信", "幫這場 demo 寫追蹤信並更新
+  CRM", "log the demo and draft the follow-up", or otherwise wants the post-demo
+  email plus the deal updated. Distinct from sales-outbound (a PRE-meeting DM →
+  new lead + first reply) and consult-project-specialist (documents a meeting
+  into a NEW project + Drive folder): this one takes ONE completed demo
+  transcript on an EXISTING deal and produces a conversion follow-up draft + a
+  light deal update — no new lead, no Drive folder, no meeting-to-project.
+category: sales-consultant
+project: sales-follow-up
+platform: claude
+status: Done
+author: Peter Tu
+sheetId: "2.10"
+input: "A completed sales demo / discovery-call transcript (Google Doc URL or pasted) for a prospect who already has a CRM deal + email thread. Optionally the deal URL and thread subject."
+process: "Parse the transcript (pains / what was shown / feedback / next steps) → map pains to solution-page capabilities → draft a threaded Gmail follow-up (never send) → sync the existing deal (demo note, refreshed summary, stage nudge, follow-up task) → report."
+output: "A threaded Gmail follow-up draft in Peter's inbox + an updated CRM deal (demo note, refreshed summary, follow-up task). Doesn't log the email — Gmail sync captures it on send."
+synergy: ["sales-outbound", "consult-project-specialist", "sales-specialist"]
+---
+
+# Sales Follow-up
+
+```bash
+npx skills add https://github.com/peter-tu-zynkr/zynkr-skill-builder --skill sales-follow-up
+```
+
+`sales-outbound` handles the *pre-meeting* moment: a DM reaches "yes, let's do a
+demo" and the skill books the lead + drafts the first reply. **`sales-follow-up`
+is the other end of that arc** — the demo happened, and now Peter wants the
+*converting* follow-up sitting in his inbox as a draft, and the deal in the CRM
+brought up to date with what actually happened on the call.
+
+From a single demo transcript it does both:
+
+1. **Drafts the follow-up email** — a threaded Gmail **draft** (never sent), in
+   the prospect's language and Peter's voice, that opens by mirroring the pain
+   points *they* raised, maps each to the matching Zynkr capability, and pushes
+   toward adopting the solution.
+2. **Syncs the existing deal** — logs the demo as a **note**, refreshes the deal
+   summary, nudges the stage if the call earned it, **closes the stale
+   "schedule the demo" task**, and books the **agreed follow-up task**.
+
+It runs **autonomously**: read transcript → draft email → update deal → report.
+No mid-run confirmation needed — the email is a *draft* (Peter reviews before
+sending) and the deal writes go through the Zynkr MCP's own preview/confirm.
+
+## How this differs from its neighbours
+
+- **sales-outbound** — PRE-meeting. One pasted DM → a *new* lead (company +
+  contact + deal) + a first reply. Use it before a demo exists.
+- **consult-project-specialist** — takes a meeting transcript and stands up a
+  whole *project*: Weekly Update + numbered Drive folder + kickoff Doc. Heavy.
+  Use it when a consulting engagement is starting.
+- **sales-follow-up** (this one) — POST-demo. One completed demo transcript on an
+  *existing* deal → a conversion follow-up draft + a *light* deal update. No new
+  lead, no Drive folder, no project scaffold.
+
+## Fixed facts (don't re-derive these)
+
+- **Supabase project_id**: `uomieoqlkazknjgmfdda` (the shared Zynkr project; CRM tables are `crm_*`).
+- **Google account** for all Gmail / Docs tools: `peter_tu@zynkr.ai`.
+- **Solution page to pitch**: `https://zynkr.ai/ai-platform` — the source of truth for capability names (Zynkr 執行模式, 知識庫, 工作指南, 名單拓展, 簡報製作, 情境工程 engine, pricing). Fetch it to ground the pitch; never invent feature names.
+- **CRM record URLs** for the report: `https://platform.zynkr.ai/deals/{id}` · `.../contacts/{id}` · `.../companies/{id}`.
+- Owner / author of any activity is the **deal's `owner_id`, resolved live** — never hardcode a user id (`auth.uid()` is NULL over MCP/SQL).
+- **Do NOT log the follow-up email as a CRM activity.** Peter's Gmail is synced into the CRM (`app/lib/integrations/sync.ts`, 15-min cron): the moment he sends the draft it auto-appears on the contact's 電子郵件 timeline as an outbound email. Logging it here would duplicate that row. The **demo** is different — it isn't in Gmail, so the demo `note` is legitimately yours to write.
+
+---
+
+## Workflow
+
+### 1 · Acquire the inputs
+
+The trigger is a **demo transcript**. Read it:
+- **Google Doc URL** → `mcp__google-workspace__get_doc_content(document_id=<url>)`.
+- **Pasted text** → read directly.
+
+Also capture anything Peter hands alongside it (don't block if absent — you can find them):
+- The **prospect's name / company** (to find the deal and the thread).
+- A **deal URL** (`…/deals/{id}`) → use that uuid directly instead of searching.
+- The **email-thread subject** (e.g. the original demo-invite) → to reply in-thread.
+
+### 2 · Parse the transcript
+
+Pull these out (infer logically, never fabricate — leave blank if absent):
+- **Pain points the prospect raised** — in *their* words. These are the spine of the email; lead with them.
+- **What was demoed** — which capabilities they actually saw.
+- **Their feedback / reactions** — what landed, what they liked, any hesitation.
+- **Pricing / plan discussed** — free tier, Plus, team/Pro, token caps.
+- **Promised next steps** — anything Peter committed to (send a recording, follow up in N days, help migrate data). These become the email's asks + the follow-up task.
+- **Language** (zh-TW vs EN) → the draft matches it.
+
+### 3 · Ground the pitch in the solution page
+
+`WebFetch https://zynkr.ai/ai-platform` and pull the current capability names +
+pricing. Map **each pain point → the capability that answers it** (e.g. "資料散在
+雲端、翻找耗時" → 知識庫 + 資料 CSV 匯入 搬遷; "報價無固定邏輯" → 知識庫 報價
+criteria; "業務在外面跑沒空 key 資料" → Zynkr 執行模式). This mapping is what makes
+the follow-up *convert* instead of just recap.
+
+### 4 · Draft the follow-up reply (Gmail draft — never send)
+
+**Find the thread** with
+`mcp__google-workspace__search_gmail_messages(query="subject:\"<subject>\" in:anywhere")`,
+then read it with `get_gmail_thread_content` to grab the **last message's**
+`Message-ID`, the `References` chain, the `thread_id`, and the recipient/Cc set.
+
+Draft the reply with
+`mcp__google-workspace__draft_gmail_message(user_google_email="peter_tu@zynkr.ai", to=<their email>, cc=<same cc as the thread>, thread_id=<id>, in_reply_to=<last Message-ID>, references=<chain>, subject="Re: <original subject>", include_signature=false, body=…)`.
+
+Shape of the email (Peter's voice — warm, concise, peer-to-peer):
+- **Open by mirroring their pain** — name the 1–2 problems they raised on the call, in their words, so they feel understood. This is the hook.
+- **Map pain → capability** — a tight bullet list, each pain answered by the Zynkr feature they saw, framed as "this is how we take that off your plate".
+- **Restate the concrete next steps** Peter promised (recording to follow, data migration help, etc.).
+- **Convert** — free-start CTA (免費開始, no credit card) + the `https://zynkr.ai/ai-platform` link; name Plus (NT$300/月) / team pricing only as the level-up, not the ask.
+- **Sales-kit line** — end with a line like「先附上 Zynkr 的介紹資料給你參考」so Peter's manually-attached kit reads naturally.
+- zh-TW house style: headings/taglines take **no 句號 (。)**; list items use **emoji numbers 1️⃣ 2️⃣ 3️⃣** (never circled ①②③); `·` for series separators.
+- **Draft only, never send.** Flag anything you were unsure about (e.g. whether the recording link goes in this mail) so Peter can adjust before sending.
+
+### 5 · Sync the existing deal (light update — Zynkr MCP)
+
+**Find the deal.** If Peter gave a deal URL, use that id. Otherwise
+`mcp__zynkr__list_deals(query="<name>")` and pick the match (confirm by
+contact/company). Read it with `mcp__zynkr__get_deal(id=…)` to see the current
+stage, notes, contact_id, company_id, owner_id.
+
+Then, in order:
+
+1. **Log the demo as a note.** Read `references/demo-note.sql`, fill the three
+   placeholders (`{{DEAL_ID}}`, `{{NOTE_SUBJECT}}`, `{{NOTE_BODY}}`) as SQL
+   literals, run via `mcp__supabase__execute_sql(project_id="uomieoqlkazknjgmfdda", query=…)`.
+   The SQL resolves author (`owner_id`), `contact_id`, and `company_id` live from
+   the deal — you only supply the deal id and the recap text. Structure the body:
+   展示內容 · 痛點 · feedback · 方案 · 下一步. (There is no Zynkr MCP tool to create a
+   `note`, which is why this one write is raw SQL.)
+2. **Refresh the deal summary** — `mcp__zynkr__update_deal(id=…, notes=<one-paragraph rolling summary>)` (preview → `confirm:true`). Rewrite `notes` from the pre-demo state to a post-demo recap: what happened, pains, that the follow-up mail is drafted, and the next step.
+3. **Nudge the stage** *only if the call earned it* — `mcp__zynkr__move_deal_stage(id=…, stage=…)`. See *Inference defaults*. Don't force `proposal` unless an actual quote/proposal was discussed; a soft pre-sales follow-up leaves a `qualified` deal at `qualified`.
+4. **Close the stale scheduling task** — `mcp__zynkr__list_tasks(filter="open")`, find the open task on THIS deal about scheduling/chasing the demo (subject mentions demo / 安排 / 追蹤…回覆), and `mcp__zynkr__set_task_status(ids=[…], status="done", confirm:true)`. The demo happened, so it's complete. If no clear match, skip and say so.
+5. **Create the follow-up task** — `mcp__zynkr__create_task(subject=…, body=…, deal_id=…, due_at=<+task_due_days, ISO 8601 UTC 'Z'>, confirm:true)`. Attach to **exactly one parent** (the deal — don't also pass contact_id, it errors). Use UTC `Z` format for `due_at` (e.g. `2026-07-06T01:00:00Z`); an offset like `+08:00` is rejected.
+
+### 6 · Report
+
+```
+Demo 跟進已就緒：超哥（行銷超哥 Chao.Marketing）
+
+| 產出 | 連結 / 狀態 |
+|------|------------|
+| Gmail 跟進草稿 | 已放進收件匣（threaded），待你過目 + 附 sales kit 後寄出 |
+| CRM Deal | <deal url>（stage: qualified → …） |
+| Demo 紀要 | note 已寫入 timeline |
+| 排程任務 | 「安排 demo」已標記完成 |
+| 跟進任務 | 7/6 跟進（已建立） |
+```
+
+Call out anything you left for Peter's judgement (a stage you did NOT auto-advance, a recording link you didn't have, a task match you weren't sure about).
+
+---
+
+## Inference defaults (Peter overrides by just saying so)
+
+- **stage** (`new|contacted|qualified|proposal|won|lost`) — advance a `new`/`contacted` deal to **`qualified`** after a real demo with engagement. Move to **`proposal`** only if a concrete quote/proposal was actually put on the table. A deal already at `qualified`+ with only a soft follow-up **stays put** — don't inflate the pipeline.
+- **task_due_days** — default **3** (chase within a few days of the demo). Use the exact interval Peter promised on the call if he named one ("我三天後跟進" → 3).
+- **note author** — always the deal's `owner_id`, resolved live.
+- **email language** — matches the transcript / thread.
+- **value / close_date** — leave untouched unless a concrete figure or date was agreed on the call.
+
+## Why it's built this way
+
+- **Transcript → both outputs.** The point is to kill the two-step (write the
+  follow-up, then go update the CRM). One transcript in; the converting draft is
+  waiting and the deal reflects reality.
+- **Lead with their pain, map to capability.** A recap email is forgettable; an
+  email that says "here's the exact thing that fixes the problem you told me
+  about" converts. That's why step 3 (ground in the solution page) exists.
+- **Email is a draft, not a send.** Outbound to a real prospect is Peter's call —
+  the skill prepares, he approves and attaches the sales kit himself.
+- **Don't log the email; do log the demo.** The Gmail→CRM sync captures the sent
+  mail on send (logging it here = a duplicate row). The demo isn't in Gmail, so
+  the demo `note` is the record only this skill can write.
+- **Update, don't create.** Post-demo the deal already exists (sales-outbound or
+  a prior touch made it). This skill finds and *updates* it — it never opens a
+  second deal for the same live opportunity.

--- a/skills/2-sales-consultant/sales-follow-up/references/demo-note.sql
+++ b/skills/2-sales-consultant/sales-follow-up/references/demo-note.sql
@@ -1,0 +1,33 @@
+-- demo-note.sql — log a completed demo as a `note` activity on an EXISTING deal.
+--
+-- Why raw SQL: the Zynkr MCP has no create-note tool (only create_task). A demo
+-- is not in Gmail, so the sync can't capture it — this note is the only record
+-- of the call, and only this skill writes it.
+--
+-- Fill THREE placeholders with SQL literals (quote text and double any single
+-- quote: O'Brien → 'O''Brien'). Everything else — the author (created_by),
+-- contact_id, company_id — is resolved LIVE from the deal, so nothing is
+-- hardcoded and it can't drift to the wrong workspace.
+--
+--   {{DEAL_ID}}       the deal uuid, quoted  e.g. '6004b982-7078-4983-8cb8-188ff1ec7432'
+--   {{NOTE_SUBJECT}}  e.g. '[DEMO] Zynkr AI 平台 Demo 紀要 — 超哥（7/3）'
+--   {{NOTE_BODY}}     the structured recap: 展示內容 · 痛點 · feedback · 方案 · 下一步
+--
+-- Run via: mcp__supabase__execute_sql(project_id="uomieoqlkazknjgmfdda", query=<this>)
+
+INSERT INTO crm_activities
+  (kind, subject, body, deal_id, contact_id, company_id, created_by, metadata, created_at, updated_at)
+SELECT
+  'note',
+  {{NOTE_SUBJECT}},
+  {{NOTE_BODY}},
+  d.id,
+  d.contact_id,
+  d.company_id,
+  d.owner_id,                                  -- author = deal owner, resolved live
+  '{"source":"manual","event":"product_demo"}'::jsonb,
+  now(),
+  now()
+FROM crm_deals d
+WHERE d.id = {{DEAL_ID}}
+RETURNING id AS note_id, deal_id;


### PR DESCRIPTION
## What

New skill **`sales-follow-up`** (sheetId `2.10`, category `2-sales-consultant`) — the **post-demo** counterpart to `sales-outbound`. From one completed demo transcript it does two things in one pass:

1. **Drafts the follow-up email** — a threaded Gmail **draft** (never sent), in the prospect's language and Peter's voice, opening by mirroring the pain points *they* raised, mapping each to the matching `zynkr.ai/ai-platform` capability, and converting toward adoption (free-start CTA + Plus/team as the level-up). Ends with a "sales kit attached manually" line.
2. **Light-syncs the existing CRM deal** — logs the demo as a `note`, refreshes the deal summary, nudges the stage only if the call earned it, closes the stale "schedule the demo" task, and books the agreed follow-up task.

Bundles `references/demo-note.sql` (the single raw-SQL write — the Zynkr MCP has no create-note tool; author/contact/company resolved live from the deal).

Captured from a real run (超哥 / 行銷超哥 Chao.Marketing demo).

## Boundaries

- **Does NOT log the follow-up email** as a CRM activity — the Gmail→CRM sync captures it on send; logging here would duplicate the row (same rule as `sales-outbound`).
- **Updates, never creates** — post-demo the deal already exists; no second deal for a live opportunity.
- Distinct from `sales-outbound` (pre-meeting DM → new lead) and `consult-project-specialist` (meeting → new project + Drive folder).

## Governance / verification

- `validate-skill.ts --tier=all` → **0 errors, 0 warnings** (IPO frontmatter tightened under the truncation caps).
- `ingest.ts` dry-run **exit 0** — sheetId `2.10` confirmed free (no duplicate throw; SKB-001 gap covered manually).
- `qa.yml` runs on the new `skills/**/SKILL.md` here (the authoritative D0/D1 gate).
- Local runtime copy installed to `~/.claude/skills/sales-follow-up/` in the same session (edit-BOTH rule) → `/sales-follow-up` is invocable now.
- CHANGELOG (`docs/CHANGELOG.md`) entry added with a Verification block.
- **D2 live-trigger deferred** to Peter's first real use (build-and-review scope — a live run drafts a real email + writes the CRM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)