### PR TITLE
feat(3-operations): operations-flow-optimization — §5.3.2 ideal-flow ordering skill

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -98,3 +98,32 @@ exact wording, timing matches the full-length run, validated OK), `validate` (fu
 timestamps were spot-checked at 6 points across the timeline against independent
 re-transcription · `qa.yml` fires on the new `skills/**/SKILL.md` on push (D0/D1
 mechanical).
+
+## 2026-07-22 — new skill: operations-flow-optimization (§5.3.2 ideal-flow ordering)
+
+`operations-flow-optimization` (sheetId `3.14`, category `3-operations`) — the lean
+"ideal flow ordering" pass from Ch5 §5.3.2 that streamlines a process *before*
+re-architecture: I→P→O validation · dependency mapping · friction elimination
+(duplicative / loop / missing) · disciplined re-sequencing gated by a payoff test
+(less rework / lower risk / higher throughput) plus the "what breaks if this step
+moves?" test. Enforces the one law **"eliminate before you automate."** Fills the gap
+where `operations-transformation` jumped SIPOC → four-quadrant → FE/BE/DB with no
+streamlining stage — that logic previously existed only as a buried 5-bullet checklist
+inside the `operations-process-redesign` agent (never surfaced, not reusable, missing
+the friction taxonomy and the whole re-sequence discipline). Ships two references:
+`sequencing-heuristics.md` (the full re-order playbook — heuristics, payoff gate,
+"what breaks?" test, decision-log format) and `worked-example.md` (event-roster
+reconciliation end-to-end, the companion case to training workshop 4.6 流程重構工作坊,
+PII-safe placeholders). Non-destructive wiring: added to `operations-transformation`
+synergy + an optional Stage 1.5 pointer between SIPOC and automation diagnosis, and
+named the canonical owner of the flow-streamlining checklist in the redesign agent.
+Intake: `zynkr-skill-idea#111` · built via draft PR #29.
+
+**Verification** (D2): M-sized skill-content add · `validate-skill.ts --tier=all` →
+0 errors, 0 warnings · sheetId `3.14` grep-confirmed unique tree-wide (the exact
+condition `ingest.ts`'s duplicate-throw guards; SKB-001 cross-file gap checked by hand)
+· method dogfooded on a fresh unseen process ("weekly social scheduling") — reproduced
+all four deliverables (I→P→O table, dependency map, friction log dropping a no-value
+copy step, re-sequence decision log with one payoff-justified move) · `qa.yml` PASS on
+PR #29 · `ingest-skills.yml` fires on the new `skills/**` on merge to main (the real
+ingest run is the definitive no-duplicate + live-on-marketplace proof).

--- a/skills/3-operations/operations-flow-optimization/SKILL.md
+++ b/skills/3-operations/operations-flow-optimization/SKILL.md
@@ -5,7 +5,7 @@ description: "Streamline and re-sequence a business process into a clean 'ideal 
 category: operations
 project: operations-flow-optimization
 platform: claude
-status: WIP
+status: Done
 author: Peter Tu
 input: "An as-is process or step list (ideally a SIPOC map), plus the outcome the process must deliver"
 process: "I→P→O validation → dependency mapping → friction elimination → disciplined re-sequencing (with a payoff test) → streamlined to-be spine + decision log"

--- a/skills/3-operations/operations-flow-optimization/SKILL.md
+++ b/skills/3-operations/operations-flow-optimization/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: operations-flow-optimization
+sheetId: "3.14"
+description: "Streamline and re-sequence a business process into a clean 'ideal flow' BEFORE it gets re-architected or automated. Runs a lean optimization pass: validate Input→Process→Output on every step, map dependencies, eliminate friction (duplicative / looping / missing steps), then apply disciplined re-sequencing only where it buys less rework, lower risk, or higher throughput. Use it whenever a process feels bloated, out of order, or 不順暢 — when someone says '幫我把流程理順', '這流程可以更精簡嗎', 'streamline this workflow', 'is my process in the right order', or right after a SIPOC / as-is map and before FE/BE/DB architecture or Lucid. Enforces 'eliminate before you automate.' Does NOT do automation-feasibility scoring or FE/BE/DB layer assignment — hand off to operations-transformation for that."
+category: operations
+project: operations-flow-optimization
+platform: claude
+status: WIP
+author: Peter Tu
+input: "An as-is process or step list (ideally a SIPOC map), plus the outcome the process must deliver"
+process: "I→P→O validation → dependency mapping → friction elimination → disciplined re-sequencing (with a payoff test) → streamlined to-be spine + decision log"
+output: "A streamlined 'ideal flow' spine (Before/After), a dependency map, a friction log, and a re-sequence decision log — ready for FE/BE/DB architecture or Lucid"
+synergy:
+  - "operations-transformation"
+  - "product-flow-design"
+  - "consult-discovery"
+---
+
+# Operations Flow Optimization
+
+```bash
+npx skills add https://github.com/peter-tu-zynkr/zynkr-skill-builder --skill operations-flow-optimization
+```
+
+Take a messy, human-grown business process and turn it into a clean **"ideal flow"** — I→P→O-valid on every step, dependency-ordered, and stripped of friction — *before* anyone re-architects or automates it. This is the lean-optimization pass that most teams skip: they jump straight from "here's our current process" to "let's automate it," and end up **automating waste**. This skill makes you earn a streamlined flow first. Use it right after a SIPOC / as-is map and right before FE/BE/DB architecture (`operations-transformation`) or drawing on Lucid (`product-flow-design`). It is deliberately *conservative about re-ordering* — it changes sequence only when the change pays for itself.
+
+The one law it enforces: **eliminate before you automate. Anchor the spine to I→P→O and dependencies; only then, rarely, re-sequence — and only for less rework, lower risk, or higher throughput.**
+
+---
+
+## Step 1 — Collect the flow
+
+Ask the user for (accept whatever they have; don't block on all three):
+
+1. **The process, as steps** — a list of the steps as they happen *today*, in current order. A SIPOC map from `operations-transformation` Stage 1 is the ideal input; a rough bullet list is fine too.
+2. **The outcome** — what the process must reliably produce when it's done (`乾淨的追蹤名單`, `approved + notified`, `月結報表`). This is the anchor everything gets tested against.
+3. **Known pain** — anything that already feels slow, repeated, error-prone, or out of order.
+
+Store as `FLOW`. If steps are vague, do **not** silently invent them — ask one clarifying question, then proceed. Restate the flow back in your own words so the user can correct it before you start cutting.
+
+> If the process isn't understood well enough to list its steps, this is the wrong skill — send the user to `consult-discovery` (pain-point discovery) or `operations-transformation` Stage 1 (SIPOC) first.
+
+---
+
+## Step 2 — Validate Input → Process → Output on every step
+
+This is the anchor. Walk each step and confirm it has all three:
+
+- **Input** — what must exist for this step to start (a file, a record, a prior output, an approval).
+- **Process** — the single verb-and-object of work it performs (`Validate request`, `Match on email`, `Draft follow-up`).
+- **Output** — the concrete artifact or state change it leaves behind.
+
+For each step, flag:
+- **Ambiguous transition** — the output of step N doesn't cleanly become the input of step N+1 (something happens "somehow" in between). Name the missing piece.
+- **No real output** — a "step" that produces nothing durable is usually a note, not a step. Merge or drop it.
+- **Fuzzy process** — a step doing two things at once. Split it so each has one I→P→O.
+
+**Deliverable: a Before/After I→P→O table.** One row per step: `Step · Input · Process · Output · flag`. Do not proceed to ordering until every kept step is I→P→O-clean — an out-of-order flow can't be diagnosed on top of undefined steps.
+
+---
+
+## Step 3 — Map dependencies
+
+Now find what actually constrains the order (as opposed to how it's habitually done):
+
+- **Hard dependency** — step B genuinely cannot start until step A's output exists (you can't reconcile a roster before both lists are exported). These fix the spine.
+- **Shared data / handoff** — two steps read or write the same record, or one hands work to a different owner. Mark the handoff explicitly.
+- **Trigger** — what kicks the whole flow off, and whether any step waits on an external event.
+
+Draw the dependencies as arrows (or swimlanes if ownership changes hands). The key output is the distinction between **what must be ordered this way (hard dependency)** and **what is merely ordered this way out of habit** — only the latter is a candidate for re-sequencing in Step 5.
+
+**Deliverable: a dependency map** (arrows / swimlanes) separating hard dependencies from habitual ones.
+
+---
+
+## Step 4 — Eliminate friction
+
+Run the lean pass. For every step and transition, test against these three friction types (this is ECRS applied to the flow — Eliminate · Combine · Rearrange · Simplify):
+
+| Friction | What it looks like | Fix |
+|---|---|---|
+| **Duplicative** | Repeated inputs, double validations, the same data re-entered | Merge, or do it **once** and reuse the output |
+| **Unnecessary loop** | A path that returns to an earlier step for no explicit reason | Streamline the sequence; if the loop is a real retry, label it as one (Step 5) |
+| **Missing** | A break that causes rework or data loss downstream (a gap where context silently drops) | Add a connector / context node |
+
+Governing test: **the flow should add value as it moves through.** A step that doesn't move the work closer to the outcome — no transformation, no decision, no durable record — is friction. Cut it.
+
+**Deliverable: a friction log** — each item as `where · type (duplicative / loop / missing) · fix`.
+
+---
+
+## Step 5 — Re-sequence — but only with a payoff
+
+Re-ordering is the **last and rarest** move, and the most abused. Most of the "ideal flow" is already fixed by Steps 2–4. Touch the order only where a clear payoff exists. Apply these heuristics (full detail in `references/sequencing-heuristics.md`):
+
+- **Anchor first, optimize second.** Lock the spine as I→P→O per node, then respect dependencies. Only *after* that do you consider a re-order.
+- **Cheap checks upstream, expensive work downstream.** Move low-cost gates early (format, required-field, permission, schema) so you never spend heavy work — human review, LLM reasoning, multi-system writes — on input that a 5-cent check would have rejected.
+- **Batch high-traffic inputs before scarce decisions; serialize where decisions branch.** If 100 requests feed 1 approver, aggregate before approval. But don't batch *past* the point where an approval outcome changes the downstream path.
+- **Keep state writes consistent with the sequence.** Don't create ghost states (e.g. notifying before the durable record exists). A durable write should land at the point the outcome becomes real.
+- **No backward loops unless they're explicit retry / escalation paths**, labeled with their condition. An unlabeled loop is almost always hiding missing validation or unclear ownership — fix that instead of drawing the loop.
+
+**The payoff gate — every re-order must buy one of three things:**
+
+> **(1) less rework · (2) lower risk · (3) higher throughput.** If a proposed re-order buys none of these, keep the original dependency-driven order. **Do not reorder to make the diagram prettier.**
+
+**The "what breaks if this step moves?" test.** Before committing any re-order, ask it. If moving the step would change meaning, violate a contract, or create an inconsistent state, it is **not** a sequencing tweak — it's a deeper redesign problem (missing input, unclear ownership, undefined output). Send it back to Step 2, don't force the move.
+
+**Deliverable: a re-sequence decision log** — each proposed move as `step moved · from→to · payoff (rework / risk / throughput) · "what breaks?" answer · kept or rejected`. A log with **zero** accepted re-orders is a valid, common, and often correct result.
+
+---
+
+## Step 6 — Emit the streamlined spine + hand off
+
+Compile the deliverable:
+
+1. **The "ideal flow" spine** — the final ordered step list, each I→P→O-clean, as a Before → After.
+2. **Dependency map** (Step 3).
+3. **Friction log** — what was eliminated and why (Step 4).
+4. **Re-sequence decision log** (Step 5).
+
+Then point at the next stage explicitly — this skill deliberately stops before architecture:
+
+```
+Next steps:
+1. Assess automation feasibility + assign FE/BE/DB layers → operations-transformation (Stage 2–3)
+2. Draw the streamlined spine as a Lucid swimlane (shape = semantics, color = ownership, V1–V13 lint) → product-flow-design
+3. Iterate — re-run this pass after the process changes
+```
+
+---
+
+## Rules
+
+- **Anchor before you optimize.** I→P→O and hard dependencies come first; friction elimination second; re-sequencing last and rarest. Never re-order on top of undefined steps.
+- **Eliminate before you automate.** If a step is waste, cutting it beats automating it. This skill's job is to shrink the flow so the *next* stage automates only what's worth automating.
+- **A re-order needs a payoff.** Less rework, lower risk, or higher throughput — or it doesn't happen. "Cleaner-looking" is not a payoff.
+- **Run the "what breaks if this moves?" test on every proposed re-order.** A move that changes meaning or breaks a contract is a redesign problem, not a sequencing one.
+- **Don't hide logic in loops.** Every backward arrow is an explicit, labeled retry / escalation with a condition, or it's a bug to fix.
+- **Stay in lane.** Do not score automation ROI, assign FE/BE/DB, or pick tools — that's `operations-transformation`. Do not draw the final diagram or run lint — that's `product-flow-design`.
+
+## Reference files
+
+- `references/sequencing-heuristics.md` — the full re-sequencing playbook: every heuristic, the payoff gate, the "what breaks?" test, worked micro-cases.
+- `references/worked-example.md` — the method run end-to-end on an event-roster reconciliation flow (the companion case to training workshop 4.6 流程重構工作坊).
+
+## Limitations
+
+- **Not discovery.** It optimizes a process you can already list. If the steps aren't understood, run `consult-discovery` or `operations-transformation` Stage 1 (SIPOC) first.
+- **Not architecture.** It stops at a clean, ordered spine. Layer assignment, automation feasibility, and MVP-stack choices belong to `operations-transformation`; the Lucid diagram + V1–V13 lint belong to `product-flow-design`.
+- **Conservative by design.** It will often accept *zero* re-orders. That's the intended behavior — most value comes from I→P→O cleanup and friction removal, not from moving boxes around.

--- a/skills/3-operations/operations-flow-optimization/references/sequencing-heuristics.md
+++ b/skills/3-operations/operations-flow-optimization/references/sequencing-heuristics.md
@@ -1,0 +1,85 @@
+# Sequencing heuristics — the re-order playbook
+
+Re-ordering is Step 5 of `operations-flow-optimization` and the **last, rarest, most-abused** move. By the time you reach it, Steps 2–4 have already fixed most of the "ideal flow": every step is I→P→O-clean, dependencies are mapped, and friction is gone. Re-sequencing only touches the steps whose order is *habitual*, not *forced*. This file is the full playbook behind Step 5.
+
+---
+
+## The prime directive
+
+> **Anchor first, optimize second.** Lock the spine as **I → P → O** per node, then respect **dependencies / handoffs**. Only *after* that do you tweak the order for risk or throughput.
+
+Everything below is subordinate to this. If a re-order fights a hard dependency or an I→P→O contract, the re-order loses.
+
+---
+
+## The five heuristics
+
+### 1. Cheap checks upstream, expensive work downstream
+Put low-cost validation gates early — format, required fields, permission, schema — so you never spend heavy steps on input that a trivial check would have rejected. "Expensive" = human review, LLM reasoning, multi-system writes, anything slow / costly / irreversible.
+
+- **Why:** a 5-cent check that fails fast saves the dollar step behind it.
+- **Micro-case:** required-field + schema check *before* routing a request to a human approver, so the approver never opens a malformed packet.
+
+### 2. Move critical risk checks earlier
+Identity, permission, eligibility, compliance — if a check can veto the whole flow, run it before you do work that would have to be undone.
+
+- **Why:** downstream rework and compliance exposure are the two most expensive things a flow can generate.
+- **Micro-case:** permission / identity check *before* initiating a transaction, not after drafting it.
+
+### 3. Batch high-traffic inputs before scarce decisions; serialize where decisions branch
+If many inputs funnel into one bottleneck (one approver, one reviewer, one rate-limited system), aggregate before the bottleneck. But stop batching at the point an outcome starts changing the downstream path.
+
+- **Why:** batching reduces thrash on the scarce resource; over-batching hides branch-relevant differences.
+- **Micro-case:** aggregate 100 similar requests into one approval packet — but *don't* batch past the approval if "approved" vs "rejected" sends items down different paths.
+
+### 4. Keep state writes consistent with the sequence — no ghost states
+When you reorder, confirm you are not creating a state that claims something is true before it durably is. The classic failure is **notifying before the durable record exists**.
+
+- **Why:** ghost states cause the worst class of bug — the system and reality disagree, and downstream steps trust the system.
+- **Rule of thumb:** a durable DB write should land *at the point the outcome becomes real*, and notifications fire *after* it.
+
+### 5. No backward loops unless they're explicit retry / escalation paths
+If a step returns upstream, it must be labeled **retry** or **escalation** with a clear condition (`on validation fail, return to intake`). An unlabeled loop is almost always hiding missing validation or unclear ownership.
+
+- **Why:** loops are where flows secretly become non-deterministic. A labeled loop is a design; an unlabeled loop is a bug.
+- **Fix, don't draw:** if you can't state the loop's condition in one clause, you have a Step 2 problem (missing input / undefined output), not a sequencing one.
+
+---
+
+## The payoff gate — the test every re-order must pass
+
+A re-order is only allowed if it buys **one of exactly three things:**
+
+| Payoff | You're buying | Signal |
+|---|---|---|
+| **Less rework** | Fewer steps redone because a problem was caught earlier | A downstream step currently fails often on something an earlier gate could catch |
+| **Lower risk** | Less chance of harm / compliance breach / irreversible mistake | A risk check currently runs after the point of no return |
+| **Higher throughput** | More work through a bottleneck per unit time | A scarce resource is thrashed by unbatched high-traffic input |
+
+**If a proposed re-order buys none of these, keep the original dependency-driven order.** "The diagram looks cleaner," "it feels more logical," and "it groups similar steps" are **not** payoffs. Reordering that doesn't pay for itself just adds risk (see the ghost-state trap) for no return.
+
+---
+
+## The "what breaks if this step moves?" test
+
+Before committing *any* re-order, ask it out loud and answer concretely:
+
+- **Nothing breaks, and it buys a payoff** → make the move, log it.
+- **Nothing breaks, but no payoff** → don't move it (payoff gate).
+- **Something breaks** — moving it would change meaning, violate a contract, or create an inconsistent state → **stop.** This is not a sequencing optimization. It's a deeper redesign problem: a missing input, unclear ownership, or an undefined output. Send the step back to Step 2 (I→P→O validation). Do not force the move to make the sequence look right.
+
+The teaching version: *if a change prevents waste (rework) or prevents harm (compliance), it can justify a minor re-order; otherwise, keep the sequence anchored to I→P→O and dependencies.*
+
+---
+
+## The decision log format
+
+Every candidate re-order — accepted or rejected — gets one row. Rejected rows matter as much as accepted ones; they show the order was examined and deliberately kept.
+
+| Step moved | From → To | Payoff (rework / risk / throughput) | "What breaks?" | Verdict |
+|---|---|---|---|---|
+| Permission check | after draft → before draft | lower risk | nothing — draft needs no permission | **keep move** |
+| Group by company | scattered → batched pre-approval | none (cosmetic) | nothing | **reject — no payoff** |
+| Notify requester | before DB write → after DB write | lower risk (no ghost state) | nothing | **keep move** |
+
+**A decision log with zero accepted moves is a valid and common outcome.** Most of a good "ideal flow" comes from I→P→O cleanup (Step 2) and friction removal (Step 4), not from moving boxes around.

--- a/skills/3-operations/operations-flow-optimization/references/worked-example.md
+++ b/skills/3-operations/operations-flow-optimization/references/worked-example.md
@@ -1,0 +1,92 @@
+# Worked example — event roster reconciliation
+
+This runs `operations-flow-optimization` end-to-end on one process: reconciling an event's sign-up list, attendance list, and CRM into a clean follow-up list. It is the companion case to training workshop **4.6 流程重構工作坊**. All names and addresses below are illustrative placeholders (`example.com`).
+
+---
+
+## Step 1 — Collect the flow
+
+**Outcome the process must deliver:** a clean follow-up list (who to email) + an exception list (who needs a human to decide), and an updated CRM.
+
+**The process, as done today (as-is):**
+
+1. Export the sign-up list to CSV
+2. Export the attendance list to CSV
+3. Eyeball / VLOOKUP the two lists to match people by name and email
+4. Mark the no-shows
+5. Clean up duplicates and missing fields by hand
+6. Copy the survivors into a follow-up spreadsheet
+7. Re-check the follow-up list against the CRM so you don't email someone twice
+8. Hand the list off; someone drafts and sends follow-up emails
+
+**Known pain:** step 3 is slow and error-prone; step 7 always turns up people who were already in the CRM *after* they'd been copied in step 6; duplicates in step 5 get missed.
+
+---
+
+## Step 2 — I → P → O validation
+
+| # | Step | Input | Process | Output | Flag |
+|---|---|---|---|---|---|
+| 1 | Export sign-ups | event platform | export | sign-up CSV | ok |
+| 2 | Export attendance | check-in tool | export | attendance CSV | ok |
+| 3 | Match lists | 2 CSVs | join on email; fuzzy on name | matched rows | **fuzzy process** — exact-match and human-judgment match are two different things jammed together |
+| 4 | Mark no-shows | matched rows | flag signed-up-but-absent | no-show flags | ok |
+| 5 | Clean dup / missing | matched rows | dedup + fix missing fields | cleaned rows | **fuzzy process** — dedup (a rule) and missing-field triage (a judgment) are two steps |
+| 6 | Copy to follow-up sheet | cleaned rows | copy/paste | follow-up sheet | **no real output** — copy/paste adds no value; it's a container move |
+| 7 | Re-check vs CRM | follow-up sheet + CRM | dedup against CRM | de-duped list | **ambiguous transition + ordering smell** — this is the same "dedup" work as step 5, done late |
+| 8 | Hand off + send | de-duped list | draft + send emails | emails sent | ok (but two steps: draft, send) |
+
+**Fixes applied in Step 2:** split step 3 into *exact match* + *fuzzy match (human judgment)*; split step 5 into *dedup (rule)* + *missing-field triage (judgment)*; drop step 6 (pure container move, no value).
+
+---
+
+## Step 3 — Dependency map
+
+- **Hard:** 1 and 2 must precede any matching (can't reconcile lists that don't exist yet). Matching must precede no-show marking.
+- **Hard:** the CRM check (old step 7) reads the CRM — but it does **not** depend on anything step 6 produced. It only needs the reconciled people. So its late position is **habitual, not forced.** ← re-sequence candidate.
+- **Handoff:** the final draft-and-send changes owner (ops → marketing). Mark it.
+- **Trigger:** "event has ended" kicks the flow off.
+
+---
+
+## Step 4 — Friction elimination
+
+| Where | Type | Fix |
+|---|---|---|
+| Step 6 (copy to follow-up sheet) | **Duplicative / no-value** | Eliminate — the reconciled table *is* the follow-up list; don't copy it into a second sheet |
+| Steps 5 & 7 both dedup | **Duplicative** | Merge into one dedup pass (see Step 5 re-sequencing — pull the CRM in early so you dedup against sign-ups, attendance, *and* CRM at once) |
+| Step 3 fuzzy match | **Missing** (no exception path) | Add a "needs human review" branch + an exception list, instead of forcing a guess inline |
+
+**Value-flow check:** every surviving step now transforms data, makes a decision, or writes a durable record. The copy/paste step (no transformation, no decision, no durable record) failed the test and was cut.
+
+---
+
+## Step 5 — Re-sequence (with payoff gate + "what breaks?")
+
+| Step moved | From → To | Payoff | "What breaks?" | Verdict |
+|---|---|---|---|---|
+| Pull in CRM contacts | after copy (step 7) → alongside the two CSVs, before matching | **less rework** — dedup once against all three sources instead of discovering CRM dups after copying | Nothing — the CRM read has no dependency on the follow-up sheet | **keep move** |
+| Exact-match gate | — → *before* fuzzy match | **less rework / lower risk** — cheap deterministic join first, so a human only ever reviews the genuinely ambiguous residue | Nothing — exact match needs no judgment | **keep move** |
+| Group follow-ups by company | scattered → grouped | none (cosmetic) | Nothing | **reject — no payoff** |
+
+Two accepted moves, both buying *less rework*; one rejected for being cosmetic. This is a healthy log.
+
+---
+
+## Step 6 — The streamlined "ideal flow" spine (Before → After)
+
+**Before:** export → export → match(fuzzy+exact jammed) → mark no-shows → clean(dedup+triage jammed) → **copy to sheet** → re-check vs CRM(late dedup) → hand off+send. *(8 steps, dedup done twice, a no-value copy, fuzzy guessing inline.)*
+
+**After:**
+
+1. Export sign-ups · Export attendance · Load CRM contacts *(all three sources up front)*
+2. **Exact-match join** on email across all three *(cheap deterministic gate first)*
+3. **Fuzzy-match** the residue → **exception list** for human review *(judgment isolated, not inline)*
+4. **Dedup once** against the unified set
+5. Mark no-shows → follow-up list
+6. Triage missing fields → exception list
+7. Hand off follow-up list → draft → send *(owner change marked)*
+
+*One dedup pass. No copy step. Exact-before-fuzzy so humans only touch ambiguity. CRM joined early so no post-hoc surprises.*
+
+**Hand-off:** this clean spine now goes to `operations-transformation` (which step is objective-high-frequency → deterministic? which is subjective → LLM suggests + human gate? assign FE/BE/DB), and then to `product-flow-design` to draw it as a Lucid swimlane and run the V1–V13 lint. This skill's job — a streamlined, I→P→O-clean, friction-free, sensibly-ordered spine — is done.

--- a/skills/3-operations/operations-transformation/SKILL.md
+++ b/skills/3-operations/operations-transformation/SKILL.md
@@ -14,6 +14,7 @@ synergy:
   - "2.14"
   - "2.15"
   - "2.16"
+  - "operations-flow-optimization"
 ---
 
 # Operations Transformation
@@ -60,6 +61,8 @@ Ask:
 ```
 Does this SIPOC map look right? (Yes / Adjust)
 ```
+
+> **Optional Stage 1.5 — streamline before you diagnose.** Before scoring automation, it usually pays to clean and re-order the flow itself: validate I→P→O on every step, map dependencies, and eliminate friction (duplicative / looping / missing steps). Invoke `operations-flow-optimization` on `SIPOC_TABLE` to produce a streamlined "ideal flow" spine, then feed that spine into Stage 2. The principle: **eliminate before you automate** — don't spend Stage 2/3 automating steps a lean pass would have deleted.
 
 ---
 

--- a/skills/3-operations/operations-transformation/agents/operations-process-redesign.md
+++ b/skills/3-operations/operations-transformation/agents/operations-process-redesign.md
@@ -106,3 +106,5 @@ Before actually building any solution, work with the client to draw a detailed p
    - Any unnecessary loops back to previous steps?
 3. Use frequency × objective-to-subjective four-quadrant approach to determine order
 4. Reference SIPOC: explain Input → Throughput → Output basic concepts
+
+> **Canonical owner of "is the flow streamlined and correctly ordered?"** — the quick checklist in step 2 above is a summary. The full method (I→P→O validation · dependency mapping · friction elimination · the disciplined re-sequencing playbook with its payoff gate and "what breaks if this moves?" test) lives in the standalone **`operations-flow-optimization`** skill. Ideally that pass runs *before* this redesign agent, so the steps handed here are already lean and well-ordered — this agent then focuses on sub-task breakdown, layer assignment, and tooling.


### PR DESCRIPTION
## What

New standalone skill **`operations-flow-optimization`** (`3-operations`, sheetId `3.14`) — the lean **"ideal flow ordering"** pass from Ch5 §5.3.2, which streamlines a process *before* it gets re-architected or automated:

1. **I→P→O validation** on every step (kill ambiguous transitions / no-output steps / fuzzy steps)
2. **Dependency mapping** — separate hard dependencies from habitual ordering
3. **Friction elimination** — duplicative → merge · loops → streamline · missing → add connector
4. **Disciplined re-sequencing** — cheap-checks-upstream, batch-vs-serialize, no ghost states, no unlabeled loops, gated by the **payoff test** (less rework / lower risk / higher throughput) and the **"what breaks if this moves?"** test

It enforces one law: **eliminate before you automate.**

## Why

`operations-transformation` jumps SIPOC → four-quadrant automation → FE/BE/DB with **no streamlining stage**. The flow-ordering logic existed only as a buried 5-bullet checklist inside the `operations-process-redesign` agent (lines 100–108) — never surfaced, not reusable, missing the friction taxonomy and the whole re-sequence discipline. This promotes it to a first-class, independently-invocable capability that slots into the empty seam:

```
consult-discovery → operations-transformation[SIPOC]
   → operations-flow-optimization  ← this PR (eliminate · simplify · sequence)
   → operations-transformation[feasibility + FE/BE/DB] → product-flow-design[Lucid]
```

It's also the deployable companion to training workshop **4.6 流程重構工作坊**, which teaches this exact step.

## Files

- **New:** `skills/3-operations/operations-flow-optimization/` — `SKILL.md` + `references/sequencing-heuristics.md` (full re-order playbook) + `references/worked-example.md` (event-roster reconciliation, PII-safe placeholders)
- **Wiring (non-destructive):** `operations-transformation/SKILL.md` — added synergy + an optional "Stage 1.5" pointer; `operations-process-redesign.md` — names this skill as the canonical owner of the flow-streamlining checklist

## Verification

- `npx tsx scripts/validate-skill.ts <new SKILL.md> --tier=all` → **0 errors, 0 warnings**
- `sheetId 3.14` confirmed unique tree-wide (SKB-001 cross-file gap checked manually)
- Method fidelity: I→P→O / dependency / friction / re-sequence heuristics + payoff gate + "what breaks?" test all lifted verbatim from Ch5 §5.3.2 — no invented terminology
- One synergy `slugs_exist` warning appears if you validate from a checkout that lacks the new skill (e.g. main); on this branch the slug resolves. Non-blocking (WARN tier).

## On merge (not done in this draft)

- Flip skill `status: WIP → Done` once dogfooded once (D2)
- Add `docs/CHANGELOG.md` record entry
- Merge to `main` triggers `ingest-skills.yml` → live on marketplace → then `/zynkr-skills` reconcile can close proposal #111

Closes intake: peter-tu-zynkr/zynkr-skill-idea#111
