### PR TITLE
fix: unbreak ingest pipeline — zynkr-support malformed frontmatter (+PII)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -127,3 +127,26 @@ all four deliverables (I→P→O table, dependency map, friction log dropping a 
 copy step, re-sequence decision log with one payoff-justified move) · `qa.yml` PASS on
 PR #29 · `ingest-skills.yml` fires on the new `skills/**` on merge to main (the real
 ingest run is the definitive no-duplicate + live-on-marketplace proof).
+
+## 2026-07-22 — fix: unbreak ingest pipeline (zynkr-support malformed frontmatter + PII)
+
+`ingest-skills.yml` had been failing on every push to main since **2026-07-15** — the
+`zynkr-support` (3.01) KB re-anchor commit left its `description` as an unquoted YAML
+scalar containing `: ` and double-quoted trigger phrases, which crashed `gray-matter`
+(`incomplete explicit mapping pair`) before ingest could emit `generated/` or POST the
+marketplace sync webhook. Net effect: the marketplace **silently stopped updating for a
+week** — nothing pushed after 2026-07-15 actually went live (including, at first, the
+`operations-flow-optimization` merge above). Surfaced when that merge's ingest run
+failed on the pre-existing bad file, not on the new skill (`✓ 3.14` ingested fine).
+
+Fixed by wrapping the description in double quotes + converting the inner trigger
+phrases to single quotes (house style). Once the file could finally be parsed,
+`validate-skill.ts` surfaced a second pre-existing ERROR — a real gmail address in a
+website-form example (`pii.personal_email`) that would have re-blocked the backstop's
+validate step — replaced with an `example.com` placeholder.
+
+**Verification**: whole-tree `gray-matter` scan → 170/170 frontmatter parse OK (was 1
+failure) · `validate-skill.ts` on zynkr-support → 0 errors (3 pre-existing WARNs left
+as non-blocking follow-ups: missing install snippet, `input`/`process` over the ingest
+truncation length) · the `ingest-skills.yml` run on this merge is the proof the pipeline
+completes again and republishes the whole 2026-07-15→now backlog to the marketplace.

--- a/skills/3-operations/zynkr-support/SKILL.md
+++ b/skills/3-operations/zynkr-support/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: zynkr-support
 sheetId: "3.01"
-description: The READ half of Peter's support loop (formerly support-reply-drafter). Parses Peter's Gmail support + inbound-sales queues, detects unreplied inquiries, identifies each inquirer's intent, and matches it against the **Zynkr platform 知識庫** (platform.zynkr.ai/kb — the single source of truth since 2026-07-15, accessed via the `zynkr` MCP server's search_kb / get_kb_article) to draft a safe reply on the thread. Drafts match the inbound language (zh-TW or EN). When the KB has no confident answer it does NOT guess — it leaves a holding reply with an inline `[[NEEDS PETER: ...]]` block flagging exactly what's missing and notifies Peter. Once Peter supplies the real answer, this skill hands the resolved thread off to /zynkr-kms, which writes it into the platform KB so the next identical question resolves automatically. Trigger whenever Peter says "/zynkr-support", "draft support replies", "process support inbox", "回覆 support 信箱", "清 support queue", "幫我回 support 信", "回覆 inbound sales", "清 sales inbox", "處理詢價信", or otherwise asks to handle the support / inbound-sales inbox.
+description: "The READ half of Peter's support loop (formerly support-reply-drafter). Parses Peter's Gmail support + inbound-sales queues, detects unreplied inquiries, identifies each inquirer's intent, and matches it against the **Zynkr platform 知識庫** (platform.zynkr.ai/kb — the single source of truth since 2026-07-15, accessed via the `zynkr` MCP server's search_kb / get_kb_article) to draft a safe reply on the thread. Drafts match the inbound language (zh-TW or EN). When the KB has no confident answer it does NOT guess — it leaves a holding reply with an inline `[[NEEDS PETER: ...]]` block flagging exactly what's missing and notifies Peter. Once Peter supplies the real answer, this skill hands the resolved thread off to /zynkr-kms, which writes it into the platform KB so the next identical question resolves automatically. Trigger whenever Peter says '/zynkr-support', 'draft support replies', 'process support inbox', '回覆 support 信箱', '清 support queue', '幫我回 support 信', '回覆 inbound sales', '清 sales inbox', '處理詢價信', or otherwise asks to handle the support / inbound-sales inbox."
 category: operations
 project: zynkr-support
 platform: claude
@@ -134,8 +134,8 @@ notification to Peter's own inbox. Body looks like:
 
 ```
 New discovery call inquiry
-Name: 王俊文
-Email: dwyanekobe@gmail.com
+Name: 王小明
+Email: inquirer@example.com
 Company: ...
 Interest: 團隊訓練
 Source page: consult


### PR DESCRIPTION
**Pipeline hotfix.** `ingest-skills.yml` has failed on every push to main since **2026-07-15** — `zynkr-support`'s `description` was an unquoted YAML scalar containing `: ` and double-quoted phrases, crashing gray-matter before ingest could emit `generated/` or POST the marketplace sync webhook. The marketplace has silently not updated for a week (this is also why the just-merged `operations-flow-optimization` #29 isn't live yet — its ingest run failed on this pre-existing bad file, not on the new skill: `✓ 3.14` ingested fine).

## Fix
- Quote the `description` (house style; inner trigger phrases → single quotes)
- Replace a real gmail in a website-form example with `example.com` (ERROR `pii.personal_email`, surfaced once the file could be parsed)

## Verification
- Whole-tree gray-matter scan → **170/170 parse OK** (was 1 failure)
- `validate-skill.ts` on zynkr-support → **0 errors** (3 pre-existing WARNs left as follow-ups: missing install snippet, input/process over length)
- The `ingest-skills.yml` run on merge is the proof the pipeline completes again and republishes the 2026-07-15→now backlog