### PR TITLE
feat(zynkr-accounting): monthly financial close skill (8.01)

### DIFF
--- a/skills/8-finance-admin/zynkr-accounting/SKILL.md
+++ b/skills/8-finance-admin/zynkr-accounting/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: zynkr-accounting
+sheetId: "8.01"
+description: >-
+  The monthly financial close for the Zynkr Finance Ledger — reconciles one month's 台北富邦 bank
+  statement against Gmail receipts, appends the rows that are missing, files the statement, and
+  mails a performance report. Give it the statement PDF and a month; it reads every line on the
+  statement as the spine of the month, sweeps the Finance Gmail label for invoices, receipts and
+  remittance notices, works out which of them are already in the ledger, and proves the month is
+  complete with a balance identity that has to hold to the dollar before anything is written.
+  Appends are proposed as one batch and applied only on a single confirmation — it never writes
+  to the ledger unasked. Trigger EAGERLY on "/zynkr-accounting", "月結", "對帳", "銀行對帳",
+  "close the month", "月度財務結算", "幫我對帳", "reconcile the statement", "把八月的帳結一結",
+  "銀行對帳單來了", "monthly close", "對一下上個月的帳", or whenever Peter hands over a 台北富邦
+  對帳單 PDF with no further direction. BOUNDARY — do NOT hijack: /zynkr-gm (the company-level
+  weekly GM brief; it reads runway, it does not keep the books), /planning-tracker-sync (the H2
+  tracker), /consult-status-report (one consulting engagement). This skill owns exactly one
+  thing: turning a month of bank activity into ledger rows and a report. It writes to the
+  Transactions tab and nowhere else, and it never touches the Financial Model tab.
+category: finance-admin
+project: zynkr-accounting
+platform: claude
+status: WIP
+author: Peter Tu
+input: "The month (YYYY-MM) plus the 台北富邦 statement PDF for it — a local path, a Drive file, or a Gmail attachment. Everything else is discovered."
+process: "Read the statement as the spine → sweep Gmail for the month → diff both against the ledger → run the balance identity gate → propose one append batch → on confirmation append, fill the derived-tab lookups, file the PDF, mail the report."
+output: "Appended Transactions rows, a filed statement PDF, and an HTML monthly report — the close result, income and cost by line, open items, and the reimbursement balance owed."
+synergy: [zynkr-gm, admin-governance]
+handoff: []
+---
+
+# zynkr-accounting
+
+This skill has a `references/` directory, so the marketplace one-file `curl` install is not enough
+for it — the reference files carry the ledger schema and the reconciliation rules, and the skill
+cannot run without them. Install it with the skills CLI instead:
+
+```bash
+npx skills add https://github.com/peter-tu-zynkr/zynkr-skill-builder --skill zynkr-accounting
+```
+
+## What this is
+
+Once a month the 台北富邦 statement arrives by mail. This skill turns it into bookkeeping: it reads
+every line on the statement, finds the paperwork for those lines in Gmail, works out what the
+ledger is already carrying, and appends only the difference. Then it files the PDF, writes a
+performance report and mails it.
+
+The statement is the **spine**, not one source among several. Several kinds of row exist *only*
+there — 分潤 receipts, inbound 匯費, card settlements — and generate no email at all. A sweep that
+starts from Gmail silently misses them. So the flow is always statement first, mail second.
+
+The month is only closed when a balance identity holds to the dollar. That gate is the point of
+the skill; everything before it is gathering, everything after it is reporting.
+
+## Before you start
+
+Read both reference files — they are the contract, and the failure modes in them are ones that
+have actually bitten:
+
+- `references/ledger-contract.md` — the 16-column schema, how the derived tabs are wired, the
+  append protocol, and what breaks the spreadsheet.
+- `references/reconciliation-rules.md` — the balance identity, the NT$15 fee rules, bundled
+  transfers, and the vendor → product-line map.
+
+Resolve these placeholders from the runtime substitution table before calling any tool:
+
+| Placeholder | What it is |
+|---|---|
+| `<your-google-workspace-account>` | The Workspace account every Google call runs as |
+| `<your-finance-ledger-sheet-id>` | The Zynkr Finance Ledger spreadsheet |
+| `<your-finance-drive-folder-id>` | The Drive folder the statements are filed into |
+
+## Step 0 — Anchor the month, then preflight
+
+Establish the month (`YYYY-MM`) from what Peter said, or from the statement's 對帳單期間 header.
+State it back before doing anything else — a close run against the wrong month is worse than no
+close.
+
+Then check three things and report them together:
+
+1. **The ledger tail.** Read the `Transactions` tab and find the last populated row. Monthly
+   Summary's `SUMPRODUCT` is hard-capped at **row 200** — if this close would cross it, say so
+   now and extend the formulas first. Do not append past a cap that silently stops summing.
+2. **Whether the month is already closed.** If rows already exist with `raw_ref` naming this
+   month's statement, this is a re-run. Reconcile as normal but expect the diff to be empty, and
+   never append a duplicate — ids are UUIDs, so the sheet will not stop you.
+3. **The statement is readable.** `pdftotext -layout <pdf>` is the reliable path; the layout flag
+   is what keeps the 支出 / 收入 / 餘額 columns apart.
+
+## Step 1 — Read the statement as the spine
+
+Extract the 當月交易明細 table into an ordered list: date, 摘要, 支出, 收入, 餘額. Capture the
+opening 承轉結餘 and the closing balance — the identity in Step 4 needs both.
+
+Ignore everything else in the PDF. A 富邦 statement is three pages of regulatory boilerplate
+wrapped around one small table; the 資產持有明細 block and the 訊息公告 numbered list carry nothing
+to book.
+
+Every line becomes a **bank line** with a status you will fill in during Step 4: `matched`,
+`missing`, `split`, or `unexplained`.
+
+## Step 2 — Sweep Gmail for the month
+
+Search the Finance label and the month's date range for the paperwork behind those bank lines,
+and for costs that never touch this account at all:
+
+- Invoices and receipts — SaaS vendors, venue, 講師費, 記帳士, 國稅局
+- Remittance and settlement notices — ACCUPASS 撥款, card settlements, client payments
+- Transfer confirmations from the bank itself, which usually name the payee the statement 摘要
+  only abbreviates
+
+Two things worth knowing. Personal-card charges (`source: personal`) will appear in mail but
+**never** on this statement — they belong in the ledger and must be excluded from the balance
+identity. And a bank line's 摘要 is often too terse to attribute on its own; the matching email is
+usually what names the counterparty.
+
+## Step 3 — Consolidate the month
+
+Build the candidate row set from three streams:
+
+1. **Bank lines** from Step 1 — every one becomes at least one ledger row.
+2. **Personal-card costs** from Step 2 — `source: personal`, `reimbursement_status: pending`.
+3. **Email-only costs** that settle off this account.
+
+Then diff the whole set against what the ledger already holds for the month. Match on amount and
+date first, counterparty second. What survives the diff is the append batch.
+
+Run the recurring-vendor completeness check here — the monthly subscriptions are known, and a
+missing month is nearly always an oversight rather than a real gap. `references/reconciliation-rules.md`
+carries the list.
+
+## Step 4 — Reconcile, and make the gate hold
+
+This is the step the skill exists for. The identity:
+
+```
+opening balance + Σ(all ledger rows for the month where source ≠ personal) = closing balance
+```
+
+Compute it. If it holds to the dollar, the month is complete and you may proceed.
+
+If it does not, the difference is a **finding**, and findings are the most valuable thing this
+skill produces. Do not paper over one. Resolve each into exactly one of:
+
+- **A missing row** — on the statement, absent from the ledger. Append it.
+- **A split** — one bank line that is two or more ledger rows. A salary transfer carrying an
+  expense reimbursement is the common case, and the 摘要 usually hints at it.
+- **A fee** — almost always NT$15. See the reference; the direction matters.
+- **A ledger row that never hit the bank** — booked as if paid from this account but absent from
+  the statement. This is a real error: either the payment method is wrong, or it settles next
+  month. **Do not silently re-date it.** Report it and let Peter rule.
+
+Show the arithmetic. State the identity, the two balances, the sum, and the residual — and show
+that the findings close the residual exactly. A gate you cannot show the working for is not a gate.
+
+## Step 5 — Append to the ledger
+
+Propose the whole batch first — every row, in full, as a table — and apply it **only** on a single
+confirmation from Peter. This is a financial record; a wrong append needs a correcting entry, not
+an undo.
+
+Where attribution is genuinely uncertain, the house convention is to **book it with a `⚠` note in
+the `notes` column rather than block on it**. Say plainly in the proposal which rows carry a ⚠ and
+what would settle them.
+
+Then follow the append protocol in `references/ledger-contract.md` exactly. It is append-only to
+`Transactions`, and there is a fill-down step afterwards that is easy to forget and silently
+corrupts the derived tabs when you do.
+
+## Step 6 — File the statement
+
+Upload the PDF to `<your-finance-drive-folder-id>`, named `台北富邦銀行 <YYYY-MM>.pdf` so the folder
+sorts chronologically. Keep the name stable — the ledger's `raw_ref` column cites the statement by
+month, and that citation is the audit trail back from a row to its evidence.
+
+Confirm the upload landed before moving on, and do not delete the local copy.
+
+## Step 7 — Build the report
+
+Compose the monthly performance report from `references/report-template.md`. It leads with the
+close result — held or did not hold — because that is what tells Peter whether to trust the rest
+of the numbers.
+
+Every figure must be one you computed in this run and can point at a source for. Operating revenue
+is **not** the ledger's `總收入` line; the reference explains what that line sweeps in and how to
+state revenue honestly.
+
+## Step 8 — Send
+
+Send the report as HTML to `<your-google-workspace-account>`, subject
+`【月結】<YYYY-MM> 財務結算 — <held | N findings>`.
+
+Then report back in the conversation: rows appended, the identity result, anything still open, and
+the ledger's remaining headroom to row 200.
+
+## Failure modes worth naming
+
+- **Writing into the Financial Model tab.** Every month column there is a spilled array formula.
+  Writing a value into one blocks the spill and turns the row into `#REF!`. This skill never
+  writes to that tab; it updates automatically from `Transactions`.
+- **Forgetting the derived-tab fill-down.** The `Income` and `Costs` tabs re-sort on every append,
+  so a back-dated row pushes the last row past the hand-filled lookup column and leaves it with a
+  blank TWD amount. The totals then quietly disagree.
+- **Closing on the ledger alone.** If you never open the statement you will miss every row that
+  has no email behind it, and the identity will look fine because you never computed it.
+- **Treating a residual as rounding.** It is not rounding. This ledger ties to the dollar.

--- a/skills/8-finance-admin/zynkr-accounting/references/ledger-contract.md
+++ b/skills/8-finance-admin/zynkr-accounting/references/ledger-contract.md
@@ -1,0 +1,143 @@
+# The ledger contract
+
+Everything in this file is about the Zynkr Finance Ledger spreadsheet
+(`<your-finance-ledger-sheet-id>`). Read it before writing a single cell.
+
+The shape of the thing: **`Transactions` is the only tab anyone writes to.** Every other tab
+derives itself from it by formula. That is what makes the ledger trustworthy, and it is also why a
+careless write breaks it in ways that are not obvious for weeks.
+
+---
+
+## 1. The `Transactions` schema
+
+Sixteen columns, A–P, append-only.
+
+| Col | Field | Notes |
+|---|---|---|
+| A | `id` | Upper-case UUID v4. Generate a fresh one per row |
+| B | `date` | `YYYY-MM-DD` — the date the money moved, not the invoice date |
+| C | `source` | `image` · `email` · `personal` · `manual` (see §2) |
+| D | `category` | `income` · `operating-cost` · `payroll` · `misc` |
+| E | `subcategory` | Free-ish, but reuse an existing value wherever one fits (§3) |
+| F | `vendor` | The counterparty. Drives the Financial Model's per-vendor rows — see the map in `reconciliation-rules.md` |
+| G | `description` | Human-readable, specific. "撥款匯費" beats "fee" |
+| H | `amount` | In the **original currency**. Negative for money out |
+| I | `currency` | `TWD` · `USD` · `EUR` … |
+| J | `tax` | Usually blank |
+| K | `notes` | Where the evidence and the doubts go. Prefix an uncertain attribution with `⚠` |
+| L | `raw_ref` | The evidence. For statement rows: `台北富邦銀行對帳單 YYYY/MM` |
+| M | `processed_at` | ISO 8601 with the `+08:00` offset |
+| N | `twd_amount` | TWD equivalent. **Every summary tab reads this, never `amount`** |
+| O | `exchange_rate` | `1` for TWD rows |
+| P | `reimbursement_status` | Only for `source: personal` — `pending` · `reimbursed` · `waived` |
+
+### The `source` values carry meaning
+
+`source` is not decoration — it decides whether a row participates in the bank reconciliation.
+
+- **`image`** — read off the bank statement itself. Often the *only* record of the transaction.
+- **`email`** — extracted from an invoice, receipt or transfer confirmation, and paid from the
+  富邦 account.
+- **`personal`** — a business expense on Peter's personal card. **Never appears on the statement.**
+  Always carries `reimbursement_status`, and is always excluded from the balance identity.
+- **`manual`** — cash or otherwise undocumented.
+
+Getting `personal` vs `email` wrong is the single most common way to break the close: an
+`email` row that was really a card charge makes the identity fail by exactly that amount, and it
+also understates what the company owes Peter.
+
+### Foreign currency
+
+Store the original `amount` and `currency`, then compute `twd_amount` at the transaction date's
+rate and record the rate in `exchange_rate`. The historical rate comes from the fawazahmed0
+currency API, dated:
+
+```
+https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@<YYYY-MM-DD>/v1/currencies/<lowercase-ccy>.json
+```
+
+Never use today's rate for a back-dated row.
+
+---
+
+## 2. How the other tabs derive themselves
+
+| Tab | Mechanism | What it means for you |
+|---|---|---|
+| `Monthly Summary` | `SUMPRODUCT` over `Transactions!$B$2:$B$200` / `$N$2:$N$200` | **Hard-capped at row 200.** Past that, rows stop being counted with no error |
+| `Income` | `=QUERY(Transactions!A:M, …)` spilling from A1, filtered to income | Column N is a **hand-filled** `VLOOKUP` that does not auto-extend |
+| `Costs` | Same shape, all non-income rows | Same hand-filled column N |
+| `Financial Model` | `MAP(…LAMBDA(…SUMIFS(…)))` array formulas in column E spilling across E:AP | **Never write into it** |
+| `Config` | Plain settings | Rarely touched |
+
+### The append protocol
+
+1. Read `Transactions` and find the last populated row, call it `n`.
+2. Write your batch to `A{n+1}:P{n+k}` with `USER_ENTERED`.
+3. **Fill down column N on `Income` and `Costs`.** This step is not optional — see below.
+4. Verify: read `Monthly Summary` for the month and confirm the new figures moved as expected.
+
+### ⚠ The fill-down, and why it bites
+
+`Income!A1` and `Costs!A1` are `QUERY(...)` formulas that **sort by date ascending**. So a
+back-dated row does not land at the bottom of those tabs — it sorts into the middle and pushes
+every later row down by one. The last row then falls past the end of the hand-filled `N` column and
+sits there with a blank `twd_amount`, and the tab's total quietly disagrees with `Transactions`.
+
+After any append, find the new last row of each tab and extend column N:
+
+```
+=IFERROR(VLOOKUP($A<row>,Transactions!$A:$N,14,FALSE),"")
+```
+
+A row appended with today's date still triggers this, because *other* rows in the batch may be
+back-dated. Always check both tabs; often only one has shifted.
+
+### ⚠ Never write into the Financial Model's month columns
+
+Reading a single month column shows plain numbers and looks static. Those numbers are **spilled**
+from an array formula in column E. Writing a value into one blocks the spill and turns the entire
+row into `#REF!` — "Array result was not expanded".
+
+To check whether a row is still live, read **column E with formulas included**, not the month
+column. The fix for a blocked row is to clear the offending cells, never to patch values back in.
+
+Adding rows to `Transactions` updates the Financial Model automatically. There is nothing to
+hand-maintain, and nothing there for this skill to write.
+
+---
+
+## 3. Subcategories in use
+
+Reuse these rather than inventing near-synonyms — the Financial Model matches some of them by
+exact string, and a novel spelling drops the row out of a line without any error.
+
+**income** — `course-revenue` · `client-payment` · `card-settlement` · `transfer` · `interest`
+
+**operating-cost** — `software` · `platform-fee` · `venue` · `advertising` · `lecturer-fee` ·
+`contractor` · `course-production` · `event-cost` · `accounting` · `photography` ·
+`video-production`
+
+**payroll** — `salary`
+
+**misc** — `tax` · `refund`
+
+⚠ **`payroll` has no catch-all row in the Financial Model.** It matches exact staff names. Project
+labour for someone outside that list must be booked as `operating-cost` / `contractor`, or it
+vanishes from the model while still being correct in Monthly Summary. Software has a catch-all
+("其他 SaaS"), so a new SaaS vendor is safe; a new *person* is not.
+
+---
+
+## 4. Verification checks
+
+After a close, these should all hold:
+
+- `Costs` column N total = `Transactions` non-income `twd_amount` total.
+- `Monthly Summary` income for the month = the sum of the month's income rows.
+- No `#REF!` anywhere in the Financial Model — spot-check the month's column.
+- The month's Financial Model column reflects the new rows in the right product line.
+
+If the last one fails but Monthly Summary is right, the cause is almost always a `vendor` string
+that no `SUMIFS` matches. Check the map in `reconciliation-rules.md`.

--- a/skills/8-finance-admin/zynkr-accounting/references/reconciliation-rules.md
+++ b/skills/8-finance-admin/zynkr-accounting/references/reconciliation-rules.md
@@ -1,0 +1,155 @@
+# Reconciliation rules
+
+How a month of 台北富邦 activity becomes ledger rows, and how you prove you got it all.
+
+---
+
+## 1. The identity
+
+```
+opening 承轉結餘  +  Σ(ledger rows for the month where source ≠ personal)  =  closing balance
+```
+
+Both balances are printed on the statement. This holds **to the dollar** — this ledger has no
+rounding slack. A residual of any size is a finding, never noise.
+
+There is a second, slower check worth running when something feels wrong:
+
+```
+Monthly Summary cumulative  +  outstanding pending personal-card spend  =  富邦 account balance
+```
+
+The second term is what the company owes Peter, and it grows every month it is not settled. It is
+also the figure the monthly report leads its liability line with.
+
+### Working the residual
+
+Take the difference between the identity's two sides and resolve it into named findings until it
+closes exactly. Every residual has a cause; the four causes are:
+
+| Finding | What it looks like | What to do |
+|---|---|---|
+| **Missing row** | On the statement, not in the ledger | Append it |
+| **Split** | One bank line = two or more ledger rows | Append the missing part |
+| **Fee** | An amount off by exactly 15 | Append the fee row (§2) |
+| **Phantom** | In the ledger, not on the statement | **Report — do not fix silently** |
+
+A phantom is the interesting one. It means a row is booked as though it were paid from this
+account when it was not. Either its `source` should be `personal`, or it settles in a later month.
+Both are Peter's call, because both change what he is owed.
+
+---
+
+## 2. The NT$15 rule, in both directions
+
+富邦 charges NT$15 per transfer, and the direction determines how it is booked.
+
+**Outbound** — the fee is added to the amount and booked on the same row. A NT$32,000 salary
+leaves the account as **32,015**, and the ledger row is `-32,015` with a note recording the split.
+No separate fee row.
+
+**Inbound** — the fee is deducted, so the money arrives NT$15 *short* of what was invoiced. How
+you book that depends on the counterparty's convention:
+
+- **Gross-booked counterparties** (ACCUPASS) — income is recorded at the gross invoice amount with
+  the platform fee as its own `platform-fee` row. The NT$15 remittance fee then needs a **third**
+  row, `operating-cost` / `platform-fee`, description `撥款匯費`, amount `-15`. Without it the
+  month is off by exactly 15.
+- **Net-booked counterparties** (the Hahow 分潤 payer) — income is recorded at the net amount that
+  actually landed, and the fee lives in the `notes` as `請款 <gross> 扣匯費 15`. No separate row.
+
+Getting this backwards is a 15- or 30-dollar residual, which is small enough to be tempting to
+ignore and is exactly the kind of thing that hides a real error later.
+
+---
+
+## 3. Bundled transfers
+
+One bank line is not always one ledger row. Peter routinely settles an expense reimbursement
+inside a salary transfer, and the 摘要 is the only clue.
+
+A 摘要 of `七月薪水和活動` on a NT$38,015 line is **three** things:
+
+```
+32,000  salary        →  payroll / salary,        -32,015  (salary + the 15 fee)
+ 6,000  event cost    →  operating-cost / event-cost,  -6,000
+    15  transfer fee  →  folded into the salary row
+```
+
+The tell is a compound 摘要 — `薪水和活動`, `薪水和場地` — or an amount that does not match the
+person's usual salary. When you split one, note the arithmetic in **both** rows' `notes` so the
+next reader can see where the other half went.
+
+---
+
+## 4. What only the statement knows
+
+These never generate an email. If the close starts from Gmail, they are simply missed, and the
+identity is what catches them:
+
+- **課程分潤 receipts** — the 摘要 may name the payer, or may say only `７月課程分潤`
+- **Inbound 匯費** — the NT$15 above
+- **Card settlements** — `ＣＤ轉收` lines from 國泰世華 / 玉山
+- **Bank interest** — a small `income` / `interest` row, usually quarterly
+- **Transfers with a bare 摘要** — `轉支`, `網路跨轉` with no counterparty
+
+For any of these where the counterparty cannot be established, book the row with a `⚠` note in
+`notes` saying exactly what is unconfirmed. Booking a flagged row beats leaving the month unclosed;
+leaving it *unflagged* is what you must not do.
+
+---
+
+## 5. Vendor → product line
+
+The Financial Model splits revenue by matching the `vendor` string. Get this wrong and the money
+lands in the wrong line while every total stays correct — which makes it hard to spot.
+
+| Product line | Matches |
+|---|---|
+| **課程 (Hahow)** | `income` / `course-revenue` where vendor matches `*Hahow*`, `*好學校*` or `*原騰*` — 好學校 **is** Hahow's Chinese name, and 原騰數位科技 / 數位簡報室 pays the Hahow 分潤 |
+| **課程 (Other)** | All other `course-revenue`, plus `card-settlement` |
+| **活動** | ACCUPASS only — `盈科泛利 (ACCUPASS)`, `ACCUPA`. Pays by 匯款 with 委託代銷 descriptions, so it never overlaps card settlements |
+| **顧問 · B2B** | `client-payment` |
+
+⚠ **`總收入` in the Financial Model is not operating revenue.** A 業外 row sweeps in everything
+whose *subcategory* is `transfer`, `interest` or `refund` **regardless of category** — including
+expense rebates booked as `misc` / `refund`. A single capital transfer in has made a month look
+like a million-dollar revenue month.
+
+Operating revenue = `總收入` − (transfer + interest + refund). State it that way in the report,
+and show the 非營業 figure separately rather than burying it.
+
+---
+
+## 6. Recurring vendors — the completeness check
+
+These bill every month. A missing month is nearly always an oversight, so check the month has one
+of each before closing. All are `source: personal`, `operating-cost` / `software`, and pending
+reimbursement unless stated.
+
+| Vendor | Cadence | Notes |
+|---|---|---|
+| Anthropic | Monthly, plus ad-hoc API top-ups | Team plan + Max plan are separate rows |
+| OpenAI | ~2nd of the month | EUR |
+| Supabase | ~1st | |
+| Vercel | ~10th | |
+| Google (Workspace) | End of month | Seat count drifts — check the invoice, don't assume |
+| Buffer | ~19th | |
+| Kit (ConvertKit) | Annual, in August | Large single charge |
+
+The bank-side recurring items are payroll (four people, around the 6th, for the *previous* month)
+and 記帳士 / 國稅局 payments, which are irregular.
+
+---
+
+## 7. The report's honest numbers
+
+When writing the monthly report:
+
+- Lead with whether the identity held. If it did not, say so before any other number.
+- Give operating revenue, not `總收入`, and show 非營業 separately.
+- Give the pending reimbursement balance — it is a real liability and it compounds.
+- Name every `⚠` row still open, with what would settle it.
+- State the ledger's remaining headroom to row 200.
+
+A report that quietly presents an unreconciled month as a clean one is worse than no report.

--- a/skills/8-finance-admin/zynkr-accounting/references/report-template.md
+++ b/skills/8-finance-admin/zynkr-accounting/references/report-template.md
@@ -1,0 +1,96 @@
+# The monthly report
+
+Shape, tone and the rules for the numbers. Sent as HTML to
+`<your-google-workspace-account>`, subject `【月結】<YYYY-MM> 財務結算 — <held | N findings>`.
+
+The report is written for one reader who already knows the business, so it does not explain what a
+分潤 is. It exists to answer three questions in order: **can I trust these numbers, what happened
+this month, and what do I owe or need to decide.**
+
+---
+
+## Section order
+
+### 1. The close result — first, always
+
+One line, before anything else:
+
+> **對帳結果**：identity held to the dollar (582,599 → 535,183，net −47,416)
+
+or
+
+> **對帳結果**：3 findings — 2 rows appended, 1 unresolved (NT$1,050)
+
+If the identity did not hold, the reader needs to know that before they read a single figure
+below. Never bury it under a summary table.
+
+### 2. The month in four numbers
+
+A small table, TWD:
+
+| | |
+|---|---|
+| 營業收入 | operating revenue — **not** `總收入` |
+| 非營業 | transfer · interest · refund, shown separately |
+| 總支出 | |
+| 淨額 | |
+
+Then one sentence naming the biggest single driver either way. "The month is negative because
+Kit's annual renewal landed" is worth more than the number alone.
+
+### 3. Income by line
+
+By product line, using the vendor map — 課程 (Hahow) · 課程 (Other) · 活動 · 顧問 · B2B. Give each
+line its amount and the counterparty behind it. If one payment dominates the month, say so.
+
+### 4. Cost by category
+
+`operating-cost` · `payroll` · `misc`, then the notable individual items. Do not list every SaaS
+subscription — group them as software and call out only what changed: a new vendor, a seat-count
+move, an annual renewal, something that stopped.
+
+### 5. Reconciliation detail
+
+Only when there were findings. For each: what it was, what was done, and — if it is still open —
+what would settle it and who has to decide.
+
+Show the arithmetic for the residual. The reader should be able to check it.
+
+### 6. What is owed
+
+The pending personal-card reimbursement balance, and how much it moved this month. This is a real
+liability that grows silently, so it gets its own line every month even when nothing changed.
+
+### 7. Open items
+
+Every `⚠` row still unresolved, with the specific question attached. If there are none, say
+"none open" rather than dropping the section — the absence is information.
+
+### 8. Ledger health
+
+One line: last row used, headroom to row 200, and anything odd noticed in the derived tabs.
+
+---
+
+## Rules for the numbers
+
+- Every figure must come from this run. If you did not compute it, do not print it.
+- TWD everywhere, from `twd_amount`. Never mix in a raw foreign `amount`.
+- Comparisons to the prior month are welcome, but only where the comparison is honest — a month
+  containing an annual renewal is not comparable to one without, and should say so.
+- Round nothing. This ledger ties to the dollar and the report should show that it does.
+
+## Tone
+
+Plain and specific. The reader is the person who runs the company; they do not need cheerleading
+and they will notice hedging. Where something is uncertain, name the uncertainty and what would
+resolve it — that is more useful than a confident number that turns out to be wrong.
+
+Headings and taglines in Chinese take no ending 句號; use `·` for series.
+
+## Styling
+
+Follow the Zynkr brand: Paper holds the page (70–80%), Ink structures it, Sage Deep for the
+thinking, and **orange at most once** — spend it on the close result if the identity failed, and
+nowhere else. Keep the table borders light and let the whitespace do the work. Graphite does not
+appear.


### PR DESCRIPTION
First skill in `8-finance-admin`. Turns the monthly 台北富邦 statement into ledger rows and a report.

## The flow

Statement PDF + a month → read the statement as the **spine** → sweep Gmail for the paperwork → diff both against the Finance Ledger → **balance identity gate** → propose one append batch → on confirmation append, fill the derived-tab lookups, file the PDF in Drive, mail an HTML report.

## Why the statement leads

Several kinds of row exist *only* on the statement — 分潤 receipts, inbound 匯費, card settlements — and generate no email at all. A Gmail-first sweep misses them silently. That is what happened before the 2026-08 close, which is where this skill's rules came from.

## What it encodes

Knowledge from the 2026-08 reconciliation, so the next close does not re-derive it:

- **The identity** — `opening + Σ(rows where source ≠ personal) = closing`, to the dollar. Everything before it is gathering; everything after is reporting.
- **NT$15 fee rules** — outbound folds the fee into the row; inbound arrives short, and whether it needs its own row depends on whether the counterparty is gross- or net-booked.
- **Bundled transfers** — one bank line can be several ledger rows (a salary transfer carrying an expense reimbursement).
- **The `Income`/`Costs` column-N fill-down** — those tabs re-sort on every append, so a back-dated row pushes the last row past the hand-filled `VLOOKUP` and leaves a blank TWD amount. Totals then quietly disagree.
- **Never writing into the Financial Model's month columns** — they are spilled array formulas; a write turns the row into `#REF!`.
- **`總收入` ≠ operating revenue** — a 業外 row sweeps in transfer/interest/refund regardless of category.

## Notes for review

- `sheetId: "8.01"` — free in the live content-id namespace. `catalog/sheet-map.json` has legacy `8.01`/`8.02` rows, but those are 2026-05 snapshot coordinates from the old numbering where `8.x` meant *sales-consultant*, and both are `kind: skip`. Nothing in `generated/` or any SKILL.md claims an `8.x` id.
- Multi-file skill, so the body carries the `npx skills add` snippet with prose before the fence (a leading fence gets stripped by the marketplace).
- Sheet and Drive identifiers are placeholders per the public-surface scrub; the substitution table needs the two new entries.
- Validator: **0 errors, 0 warnings**.
- Opened as a PR rather than pushed to `main` because the auto-mode classifier blocked the direct push.

Spec: SKB-026